### PR TITLE
Fix mobile pinch to zoom gesture

### DIFF
--- a/web/src/lib/services/map/pointerDragZoom.ts
+++ b/web/src/lib/services/map/pointerDragZoom.ts
@@ -21,17 +21,13 @@ export class PointerDragZoomController {
     attachDoubleTapDragZoom(element: HTMLElement) {
         let lastTapTime = 0;
         let tapCount = 0;
-        // Track active touch pointer ids without relying on ES2015 Set to satisfy strict linters
-        const activeTouchPointers: {[pointerId: number]: true} = {};
+        // Track only the count of active touch contacts (simpler than per-id bookkeeping)
         let activeTouchCount = 0;
 
         const onPointerDown = (event: PointerEvent) => {
             // Apply multi-touch guard only for touch inputs.
             if (event.pointerType === 'touch') {
-                if (!activeTouchPointers[event.pointerId]) {
-                    activeTouchPointers[event.pointerId] = true;
-                    activeTouchCount++;
-                }
+                activeTouchCount++;
                 const isMultiTouch = activeTouchCount > 1;
                 if (isMultiTouch || !event.isPrimary) {
                     tapCount = 0;
@@ -65,12 +61,9 @@ export class PointerDragZoomController {
         }, 16); // ~60fps
 
         const endGesture = (event: PointerEvent) => {
-            // Keep active touch pointer bookkeeping in sync even if no active zoom gesture
+            // Keep active touch count in sync even if no active zoom gesture
             if (event.pointerType === 'touch') {
-                if (activeTouchPointers[event.pointerId]) {
-                    delete activeTouchPointers[event.pointerId];
-                    activeTouchCount = Math.max(0, activeTouchCount - 1);
-                }
+                activeTouchCount = Math.max(0, activeTouchCount - 1);
             }
             if (!this.isActive || event.pointerId !== this.activePointerId) {
                 return;

--- a/web/src/lib/services/map/pointerDragZoom.ts
+++ b/web/src/lib/services/map/pointerDragZoom.ts
@@ -1,4 +1,4 @@
-import {throttle} from '../../utils';
+import {throttle} from '$lib/utils.js';
 
 export type PointerDragZoomOptions = {
     getZoom(): number;

--- a/web/src/lib/services/map/pointerDragZoom.ts
+++ b/web/src/lib/services/map/pointerDragZoom.ts
@@ -21,18 +21,16 @@ export class PointerDragZoomController {
     attachDoubleTapDragZoom(element: HTMLElement) {
         let lastTapTime = 0;
         let tapCount = 0;
-        // Track only the count of active touch contacts (simpler than per-id bookkeeping)
         let activeTouchCount = 0;
 
         const onPointerDown = (event: PointerEvent) => {
-            // Apply multi-touch guard only for touch inputs.
             if (event.pointerType === 'touch') {
                 activeTouchCount++;
                 const isMultiTouch = activeTouchCount > 1;
                 if (isMultiTouch || !event.isPrimary) {
                     tapCount = 0;
                     lastTapTime = 0;
-                    return; // allow pinch/other gestures to propagate
+                    return;
                 }
             }
 
@@ -61,13 +59,14 @@ export class PointerDragZoomController {
         }, 16); // ~60fps
 
         const endGesture = (event: PointerEvent) => {
-            // Keep active touch count in sync even if no active zoom gesture
             if (event.pointerType === 'touch') {
                 activeTouchCount = Math.max(0, activeTouchCount - 1);
             }
+
             if (!this.isActive || event.pointerId !== this.activePointerId) {
                 return;
             }
+
             this.activePointerId = null;
             this.end();
             try {

--- a/web/src/lib/services/map/pointerDragZoom.ts
+++ b/web/src/lib/services/map/pointerDragZoom.ts
@@ -1,4 +1,4 @@
-import {throttle} from '$lib/utils.js';
+import {throttle} from '$lib/utils';
 
 export type PointerDragZoomOptions = {
     getZoom(): number;

--- a/web/src/lib/services/map/pointerDragZoom.ts
+++ b/web/src/lib/services/map/pointerDragZoom.ts
@@ -1,4 +1,33 @@
-import {throttle} from '$lib/utils';
+// Lightweight throttle to limit pointermove handling frequency without external deps
+function throttle<T extends (...args: any[]) => void>(fn: T, wait: number): T {
+    let lastInvokeMs = 0;
+    let timeoutId: number | undefined;
+    let lastArgs: any[] | undefined;
+    let lastThis: any;
+
+    const invoke = () => {
+        lastInvokeMs = Date.now();
+        timeoutId = undefined;
+        fn.apply(lastThis, lastArgs as any[]);
+    };
+
+    return function throttled(this: any, ...args: any[]) {
+        const now = Date.now();
+        const remaining = wait - (now - lastInvokeMs);
+        lastArgs = args;
+        lastThis = this;
+
+        if (remaining <= 0 || remaining > wait) {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+                timeoutId = undefined;
+            }
+            invoke();
+        } else if (timeoutId === undefined) {
+            timeoutId = window.setTimeout(invoke, remaining);
+        }
+    } as unknown as T;
+}
 
 export type PointerDragZoomOptions = {
     getZoom(): number;
@@ -21,8 +50,30 @@ export class PointerDragZoomController {
     attachDoubleTapDragZoom(element: HTMLElement) {
         let lastTapTime = 0;
         let tapCount = 0;
+        // Track active touch pointer ids without relying on ES2015 Set to satisfy strict linters
+        const activeTouchPointers: {[pointerId: number]: true} = {};
+        let activeTouchCount = 0;
 
         const onPointerDown = (event: PointerEvent) => {
+            // Only consider touch input for double-tap detection
+            if (event.pointerType !== 'touch') {
+                return;
+            }
+
+            // Track active touch pointers to detect multi-touch (pinch/zoom)
+            if (!activeTouchPointers[event.pointerId]) {
+                activeTouchPointers[event.pointerId] = true;
+                activeTouchCount++;
+            }
+            const isMultiTouch = activeTouchCount > 1;
+
+            // Ignore and reset any double-tap logic when multiple touches are present
+            if (isMultiTouch || !event.isPrimary) {
+                tapCount = 0;
+                lastTapTime = 0;
+                return; // allow pinch/other gestures to propagate to underlying handlers
+            }
+
             const now = Date.now();
             tapCount = now - lastTapTime < 500 ? tapCount + 1 : 1;
             lastTapTime = now;
@@ -48,6 +99,13 @@ export class PointerDragZoomController {
         }, 16); // ~60fps
 
         const endGesture = (event: PointerEvent) => {
+            // Keep active touch pointer bookkeeping in sync even if no active zoom gesture
+            if (event.pointerType === 'touch') {
+                if (activeTouchPointers[event.pointerId]) {
+                    delete activeTouchPointers[event.pointerId];
+                    activeTouchCount = Math.max(0, activeTouchCount - 1);
+                }
+            }
             if (!this.isActive || event.pointerId !== this.activePointerId) {
                 return;
             }


### PR DESCRIPTION
Prevent two-finger pinch gestures from triggering double-tap drag-zoom on mobile.

The existing double-tap detection in `pointerDragZoom.ts` was sensitive to multiple simultaneous touches, causing a two-finger pinch gesture to be incorrectly registered as a double-tap. This led to the map initiating a drag-zoom instead of allowing native pinch-to-zoom. The fix introduces a multi-touch guard to ensure only primary single-touch events are considered for double-tap detection, allowing proper pinch-to-zoom behavior. A local `throttle` utility was also inlined to resolve an import error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d42e00d0-1b6f-436b-b463-2787f6965c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d42e00d0-1b6f-436b-b463-2787f6965c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents unintended zooms during multi-touch interactions on the map; only single-finger taps now trigger double-tap zoom.
  - Improves reliability of touch gestures by distinguishing single- vs. multi-finger touches, reducing accidental zooms when panning or using two fingers.
  - Preserves existing mouse/desktop gesture behavior with no changes to interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->