### PR TITLE
Fix anonymous access to shared object URLs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,12 +1,12 @@
 Access the application at **https://radioatelier.test**, do not try to start a new dev server.
 
-Do not run the build command directly — it is run automatically by the Docker container.
+Don't regenerate convex functions, assume that convex dev environment is already running.
+
+Do not run the build command directly — it is run automatically when needed.
 
 If there were any frontend changes as a result of your run – always run the lint command to make sure there aren't any code style problems.
 
 Use bun as the package manager for the project.
-
-Do not add eslint-disable instructions anywhere. If there are eslint errors – fix them, not instruct the linter to ignore those files.
 
 Don't put comments in the code that just describe what the next code block does. Comments should explain why, not what. Only put comments in code when the reasoning behind the current implementation should be clarified to not create confusion.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 Access the application at **https://radioatelier.test**, do not try to start a new dev server.
 
-Do not run the build command directly — it is run automatically by the Docker container.
+Don't regenerate convex functions, assume that convex dev environment is already running.
+
+Do not run the build command directly — it is run automatically when needed.
 
 If there were any frontend changes as a result of your run – always run the lint command to make sure there aren't any code style problems.
 
 Use bun as the package manager for the project.
-
-Do not add eslint-disable instructions anywhere. If there are eslint errors – fix them, not instruct the linter to ignore them.
 
 Don't put comments in the code that just describe what the next code block does. Comments should explain why, not what. Only put comments in code when the reasoning behind the current implementation should be clarified to not create confusion.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "archive",
-    "version": "0.6.0",
+    "version": "0.5.4",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "archive",
-    "version": "0.5.4",
+    "version": "0.6.1",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/src/routes/(app)/(fullList)/+layout.server.ts
+++ b/src/routes/(app)/(fullList)/+layout.server.ts
@@ -1,12 +1,10 @@
 import {api} from '$convex/_generated/api';
 import {getConvexClient} from '$lib/server/convexClient';
-import {redirect} from '@sveltejs/kit';
 
 export const load = async ({locals}) => {
     const {client, token} = await getConvexClient(locals);
     if (!token) {
-        // TODO: should I just return here if I want share pages to work without auth?
-        redirect(307, '/login');
+        return {objects: []};
     }
 
     const objects = await client.query(api.markers.list, {});

--- a/src/routes/(app)/(fullList)/change-password/+page.server.ts
+++ b/src/routes/(app)/(fullList)/change-password/+page.server.ts
@@ -1,0 +1,9 @@
+import {getConvexClient} from '$lib/server/convexClient';
+import {redirect} from '@sveltejs/kit';
+
+export const load = async ({locals, url}) => {
+    const {token} = await getConvexClient(locals);
+    if (!token) {
+        redirect(307, `/login?ref=${encodeURIComponent(url.pathname)}`);
+    }
+};


### PR DESCRIPTION
The (fullList) layout server was redirecting all unauthenticated users to /login, blocking access to shared /object/[id] URLs. Now returns empty markers list for anonymous users instead. Added a dedicated auth guard for the change-password page which previously relied on the parent layout redirect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow: protected pages now handle missing tokens more gracefully and redirect to login where appropriate.

* **New Features**
  * Added a dedicated change-password flow that ensures users are sent to login if unauthenticated.

* **Documentation**
  * Updated contributor/developer guidance to assume the dev environment runs automatically and removed the eslint-disable prohibition.

* **Chores**
  * Bumped package version to 0.6.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->