### PR TITLE
Fix Enter behavior in object edit form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Radioatelier. Archive",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "private": true,
     "engines": {
         "node": ">=22.9.0",

--- a/src/lib/components/objectDetails/editMode/deleteButton.svelte
+++ b/src/lib/components/objectDetails/editMode/deleteButton.svelte
@@ -56,11 +56,7 @@
         </Header>
         <Footer>
             <Cancel>Отменить</Cancel>
-            <Action
-                class="bg-destructive hover:bg-destructive/70"
-                onclick={handleClick}
-                {disabled}
-            >
+            <Action class="bg-destructive hover:bg-destructive/70" onclick={handleClick} {disabled}>
                 Удалить
             </Action>
         </Footer>

--- a/src/lib/components/objectDetails/editMode/deleteButton.svelte
+++ b/src/lib/components/objectDetails/editMode/deleteButton.svelte
@@ -14,16 +14,21 @@
     import {cn} from '$lib/utils.ts';
 
     interface Props {
-        onClick(): void;
+        disabled?: boolean;
     }
 
-    let {onClick}: Props = $props();
+    let {disabled = false}: Props = $props();
     let isOpen = $state(false);
+    let deleteButton: HTMLButtonElement;
 
     function handleClick() {
+        if (disabled) {
+            return;
+        }
+
         isOpen = false;
         setTimeout(() => {
-            onClick();
+            deleteButton.click();
         }, 150);
     }
 </script>
@@ -31,10 +36,19 @@
 <AlertDialogRoot bind:open={isOpen}>
     <Trigger
         type="button"
+        {disabled}
         class={cn([buttonVariants({variant: 'ghost'}), 'text-destructive hover:text-destructive'])}
     >
         Удалить
     </Trigger>
+    <button
+        type="submit"
+        formaction="?/delete"
+        hidden
+        bind:this={deleteButton}
+        aria-label="Удалить"
+        {disabled}
+    ></button>
     <Content>
         <Header>
             <Title>Вы действительно хотите удалить точку?</Title>
@@ -42,7 +56,11 @@
         </Header>
         <Footer>
             <Cancel>Отменить</Cancel>
-            <Action class="bg-destructive hover:bg-destructive/70" onclick={handleClick}>
+            <Action
+                class="bg-destructive hover:bg-destructive/70"
+                onclick={handleClick}
+                {disabled}
+            >
                 Удалить
             </Action>
         </Footer>

--- a/src/lib/components/objectDetails/editMode/form.svelte
+++ b/src/lib/components/objectDetails/editMode/form.svelte
@@ -43,7 +43,6 @@
     let imagePreviewUrl: string | undefined = $derived(initialValues.cover?.previewUrl);
 
     let lastAction = '';
-    let deleteButton: HTMLButtonElement;
     let submitPromise: {resolve(value: unknown): void; reject(value?: unknown): void} | null = null;
 
     function getFormData() {
@@ -149,10 +148,6 @@
         }
     });
 
-    function handleDelete() {
-        deleteButton.click();
-    }
-
     function handleBack() {
         activeObject.isEditing = false;
     }
@@ -206,16 +201,9 @@
         {#if $formData.id}
             <BackButton isConfirmationRequired={isTainted()} onClick={handleBack} />
             <span class="flex-1"></span>
-            <DeleteButton onClick={handleDelete} />
+            <DeleteButton disabled={$submitting} />
         {/if}
     </div>
-    <button
-        type="submit"
-        formaction="?/delete"
-        hidden
-        bind:this={deleteButton}
-        aria-label="Удалить"
-    ></button>
     <div class="h-[calc(100vh-8px*2-57px*2)] overflow-x-hidden overflow-y-auto p-4">
         <FormField {form} name="cover" class="mb-6">
             <FormControl>

--- a/src/lib/components/objectDetails/editMode/form.svelte
+++ b/src/lib/components/objectDetails/editMode/form.svelte
@@ -201,13 +201,6 @@
 </script>
 
 <form method="POST" action="?/save" use:enhance>
-    <button
-        type="submit"
-        formaction="?/delete"
-        hidden
-        bind:this={deleteButton}
-        aria-label="Удалить"
-    ></button>
     <div class="bg-muted/40 flex items-center justify-between gap-3 border-b px-4 py-2.5">
         <Button type="submit" disabled={$submitting} class="px-6 text-base">Сохранить</Button>
         {#if $formData.id}
@@ -216,6 +209,13 @@
             <DeleteButton onClick={handleDelete} />
         {/if}
     </div>
+    <button
+        type="submit"
+        formaction="?/delete"
+        hidden
+        bind:this={deleteButton}
+        aria-label="Удалить"
+    ></button>
     <div class="h-[calc(100vh-8px*2-57px*2)] overflow-x-hidden overflow-y-auto p-4">
         <FormField {form} name="cover" class="mb-6">
             <FormControl>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make Enter in the full object edit form use the save submit action
- move the hidden delete submit bridge into `DeleteButton`, so the form no longer owns that implementation detail
- keep the confirmed delete flow submitting through the form with `?/delete`

## Testing
- `/home/ubuntu/.bun/bin/bun run lint`
- `/home/ubuntu/.bun/bin/bun run check` *(fails due to pre-existing unrelated issues: missing `PUBLIC_CONVEX_URL` export in `$env/static/public` and existing Svelte warnings in other files)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-425a6a04-f6d6-464d-8313-02db1bf50144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-425a6a04-f6d6-464d-8313-02db1bf50144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

