### PR TITLE
Add shareable search URL via query params

### DIFF
--- a/src/lib/components/search/search.svelte
+++ b/src/lib/components/search/search.svelte
@@ -2,7 +2,11 @@
     import SearchBar from '$lib/components/search/searchBar.svelte';
     import SearchPreview from '$lib/components/search/searchPreview.svelte';
     import SearchResults from '$lib/components/search/searchResults.svelte';
-    import {searchState, applyUrlToSearchState, buildSearchUrl} from '$lib/components/search/search.svelte.ts';
+    import {
+        searchState,
+        applyUrlToSearchState,
+        buildSearchUrl,
+    } from '$lib/components/search/search.svelte.ts';
     import {onDestroy, onMount} from 'svelte';
     import SearchAreaButton from './searchAreaButton.svelte';
     import {mapState} from '$lib/state/map.svelte';
@@ -21,6 +25,8 @@
         const applied = applyUrlToSearchState(page.url);
         if (applied) {
             setCenter(Number(searchState.lat), Number(searchState.lng));
+            centerLat = searchState.lat;
+            centerLng = searchState.lng;
         }
     });
 

--- a/src/lib/components/search/search.svelte
+++ b/src/lib/components/search/search.svelte
@@ -2,10 +2,13 @@
     import SearchBar from '$lib/components/search/searchBar.svelte';
     import SearchPreview from '$lib/components/search/searchPreview.svelte';
     import SearchResults from '$lib/components/search/searchResults.svelte';
-    import {searchState} from '$lib/components/search/search.svelte.ts';
+    import {searchState, applyUrlToSearchState, buildSearchUrl} from '$lib/components/search/search.svelte.ts';
     import {onDestroy, onMount} from 'svelte';
     import SearchAreaButton from './searchAreaButton.svelte';
     import {mapState} from '$lib/state/map.svelte';
+    import {page} from '$app/state';
+    import {replaceState} from '$app/navigation';
+    import {setCenter} from '$lib/services/map/map.svelte';
 
     let centerLat = $state('');
     let centerLng = $state('');
@@ -14,6 +17,26 @@
     onMount(() => {
         updateCenter();
         listener = mapState.map!.addListener('dragend', updateCenter);
+
+        const applied = applyUrlToSearchState(page.url);
+        if (applied) {
+            setCenter(Number(searchState.lat), Number(searchState.lng));
+        }
+    });
+
+    $effect(() => {
+        if (searchState.query && searchState.lat && searchState.lng && searchState.isResultsShown) {
+            if (page.url.pathname === '/') {
+                const url = buildSearchUrl({
+                    query: searchState.query,
+                    lat: searchState.lat,
+                    lng: searchState.lng,
+                });
+                replaceState(url, {});
+            }
+        } else if (!searchState.query && page.url.pathname === '/' && page.url.search) {
+            replaceState('/', {});
+        }
     });
 
     function updateCenter() {

--- a/src/lib/components/search/search.svelte.ts
+++ b/src/lib/components/search/search.svelte.ts
@@ -1,3 +1,5 @@
+import {normalizeLatitude, normalizeLongitude} from '$lib/utils/coordinates.ts';
+
 export const searchState = $state({
     query: '',
     lat: '',
@@ -7,23 +9,31 @@ export const searchState = $state({
 });
 
 export function buildSearchUrl(params: {query: string; lat: string; lng: string}): string {
-    const sp = new URLSearchParams();
-    if (params.query) sp.set('q', params.query);
-    if (params.lat) sp.set('lat', params.lat);
-    if (params.lng) sp.set('lng', params.lng);
-    const qs = sp.toString();
+    // We don't do anything that can break reactivity, so it's safe to call the standard class here
+    /* eslint-disable-next-line svelte/prefer-svelte-reactivity */
+    const searchParams = new URLSearchParams();
+    if (params.query) {
+        searchParams.set('q', params.query);
+    }
+    if (params.lat) {
+        searchParams.set('lat', params.lat);
+    }
+    if (params.lng) {
+        searchParams.set('lng', params.lng);
+    }
+    const qs = searchParams.toString();
     return qs ? `/?${qs}` : '/';
 }
 
 export function applyUrlToSearchState(url: URL): boolean {
-    const q = url.searchParams.get('q') ?? '';
-    const lat = url.searchParams.get('lat') ?? '';
-    const lng = url.searchParams.get('lng') ?? '';
+    const q = url.searchParams.get('q')?.trim() ?? '';
+    const lat = normalizeLatitude(url.searchParams.get('lat'));
+    const lng = normalizeLongitude(url.searchParams.get('lng'));
 
-    if (q && lat && lng) {
+    if (q && lat !== null && lng !== null) {
         searchState.query = q;
-        searchState.lat = lat;
-        searchState.lng = lng;
+        searchState.lat = lat.toString();
+        searchState.lng = lng.toString();
         searchState.isResultsShown = true;
         return true;
     }

--- a/src/lib/components/search/search.svelte.ts
+++ b/src/lib/components/search/search.svelte.ts
@@ -5,3 +5,39 @@ export const searchState = $state({
     isResultsShown: false,
     isResultsMinimized: false,
 });
+
+export function buildSearchUrl(params: {query: string; lat: string; lng: string}): string {
+    const sp = new URLSearchParams();
+    if (params.query) sp.set('q', params.query);
+    if (params.lat) sp.set('lat', params.lat);
+    if (params.lng) sp.set('lng', params.lng);
+    const qs = sp.toString();
+    return qs ? `/?${qs}` : '/';
+}
+
+export function applyUrlToSearchState(url: URL): boolean {
+    const q = url.searchParams.get('q') ?? '';
+    const lat = url.searchParams.get('lat') ?? '';
+    const lng = url.searchParams.get('lng') ?? '';
+
+    if (q && lat && lng) {
+        searchState.query = q;
+        searchState.lat = lat;
+        searchState.lng = lng;
+        searchState.isResultsShown = true;
+        return true;
+    }
+
+    return false;
+}
+
+export function getActiveSearchUrl(): string | null {
+    if (searchState.query && searchState.lat && searchState.lng && searchState.isResultsShown) {
+        return buildSearchUrl({
+            query: searchState.query,
+            lat: searchState.lat,
+            lng: searchState.lng,
+        });
+    }
+    return null;
+}

--- a/src/lib/components/search/searchBar.svelte
+++ b/src/lib/components/search/searchBar.svelte
@@ -6,15 +6,14 @@
     import {Input} from '$lib/components/ui/input';
     import {fade} from 'svelte/transition';
     import {cubicInOut} from 'svelte/easing';
-    import {onMount} from 'svelte';
     import SearchIcon from '@lucide/svelte/icons/search';
 
     let val: string = $state('');
     let timeout: number | undefined;
     let isFocused = $state(false);
 
-    onMount(() => {
-        if (searchState.query) {
+    $effect(() => {
+        if (!isFocused && !timeout && val !== searchState.query) {
             val = searchState.query;
         }
     });

--- a/src/lib/components/search/searchBar.svelte
+++ b/src/lib/components/search/searchBar.svelte
@@ -6,11 +6,18 @@
     import {Input} from '$lib/components/ui/input';
     import {fade} from 'svelte/transition';
     import {cubicInOut} from 'svelte/easing';
+    import {onMount} from 'svelte';
     import SearchIcon from '@lucide/svelte/icons/search';
 
     let val: string = $state('');
     let timeout: number | undefined;
     let isFocused = $state(false);
+
+    onMount(() => {
+        if (searchState.query) {
+            val = searchState.query;
+        }
+    });
 
     function handleInput(evt: Event) {
         val = (evt.target as HTMLInputElement).value;

--- a/src/lib/utils/coordinates.ts
+++ b/src/lib/utils/coordinates.ts
@@ -2,7 +2,7 @@ const LATITUDE_LIMIT = 90;
 const LONGITUDE_LIMIT = 180;
 
 function normalizeCoordinate(value: string | null, limit: number): number | null {
-    if (value === null) {
+    if (value === null || value.trim() === '') {
         return null;
     }
 

--- a/src/lib/utils/coordinates.ts
+++ b/src/lib/utils/coordinates.ts
@@ -1,0 +1,23 @@
+const LATITUDE_LIMIT = 90;
+const LONGITUDE_LIMIT = 180;
+
+function normalizeCoordinate(value: string | null, limit: number): number | null {
+    if (value === null) {
+        return null;
+    }
+
+    const normalizedValue = Number(value);
+    if (Number.isFinite(normalizedValue) && Math.abs(normalizedValue) <= limit) {
+        return normalizedValue;
+    }
+
+    return null;
+}
+
+export function normalizeLatitude(value: string | null): number | null {
+    return normalizeCoordinate(value, LATITUDE_LIMIT);
+}
+
+export function normalizeLongitude(value: string | null): number | null {
+    return normalizeCoordinate(value, LONGITUDE_LIMIT);
+}

--- a/src/routes/(app)/(fullList)/object/[id]/+layout.svelte
+++ b/src/routes/(app)/(fullList)/object/[id]/+layout.svelte
@@ -8,6 +8,7 @@
     import type {Id} from '$convex/_generated/dataModel';
     import {useClerkContext} from 'svelte-clerk';
     import {activeObject} from '$lib/state/activeObject.svelte.ts';
+    import {getActiveSearchUrl} from '$lib/components/search/search.svelte.ts';
     import ObjectDetails from '$lib/components/objectDetails/objectDetails.svelte';
     import type {Object as ObjectType} from '$lib/interfaces/object.ts';
 
@@ -59,7 +60,7 @@
 
     function handleOverlayOutroEnd() {
         if (ctx.auth.userId) {
-            goto('/');
+            goto(getActiveSearchUrl() ?? '/');
         }
     }
 

--- a/src/routes/(app)/(fullList)/object/create/+page.server.ts
+++ b/src/routes/(app)/(fullList)/object/create/+page.server.ts
@@ -1,6 +1,7 @@
 import {api} from '$convex/_generated/api.js';
 import {schema} from '$lib/schema/objectSchema.ts';
 import {getConvexClient} from '$lib/server/convexClient';
+import {normalizeLatitude, normalizeLongitude} from '$lib/utils/coordinates.ts';
 import {type Actions, error, fail, redirect} from '@sveltejs/kit';
 import {superValidate} from 'sveltekit-superforms';
 import {zod4} from 'sveltekit-superforms/adapters';
@@ -11,8 +12,11 @@ export const load = async ({url, locals}) => {
         redirect(307, `/login?ref=${encodeURIComponent(url.pathname)}`);
     }
 
-    const latitude = normalizeLattitude(url.searchParams.get('lat') ?? '');
-    const longitude = normalizeLongitude(url.searchParams.get('lng') ?? '');
+    const latitude = normalizeLatitude(url.searchParams.get('lat'));
+    const longitude = normalizeLongitude(url.searchParams.get('lng'));
+    if (latitude === null || longitude === null) {
+        redirect(307, '/');
+    }
 
     const address = client.action(api.locations.getAddress, {latitude, longitude});
 
@@ -70,19 +74,3 @@ export const actions: Actions = {
         }
     },
 };
-
-function normalizeLattitude(value: string): number {
-    const normalizedValue = parseFloat(value);
-    if (isFinite(normalizedValue) && Math.abs(normalizedValue) <= 90) {
-        return normalizedValue;
-    }
-    redirect(307, '/');
-}
-
-function normalizeLongitude(value: string): number {
-    const normalizedValue = parseFloat(value);
-    if (isFinite(normalizedValue) && Math.abs(normalizedValue) <= 180) {
-        return normalizedValue;
-    }
-    redirect(307, '/');
-}


### PR DESCRIPTION
Sync search state (query, lat, lng) to URL query parameters on the root route so search links can be shared and bookmarked. Closing the object details overlay now returns to the search URL instead of bare / when a search is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search query, coordinates and map center now sync with the browser URL (shareable links and cleaner back/forward behavior).
  * Search input updates from external changes when not focused.
  * Navigation back from overlays redirects to the active search URL when available.

* **Bug Fixes**
  * Coordinate inputs are validated centrally to prevent invalid location parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->