### PR TITLE
fix: optional source field on object create form

### DIFF
--- a/src/lib/schema/objectSchema.ts
+++ b/src/lib/schema/objectSchema.ts
@@ -65,7 +65,7 @@ export const schema = z.object({
         z.string().max(20, 'Слишком длинный период утраты').nullable(),
     ),
     source: z.preprocess(
-        v => (v === '' ? null : v),
+        emptyOrMissingToNull,
         z.union([z.url('Должна быть валидной ссылкой'), z.null()]),
     ),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The object form schema only normalized empty string (`''`) to `null` for `source`. When the field was omitted from the POST body, superforms passed `undefined`, which did not match `z.url()` or `z.null()` and caused validation to fail—making source effectively required.

## Changes

- Use the existing `emptyOrMissingToNull` preprocessor for `source`, consistent with other nullable string fields (`description`, `address`, etc.), so missing and empty values both validate as `null`.

## Testing

- Lint could not be run in this environment (`bun` unavailable, `node_modules` not installed). Please run `bun run lint` locally after install if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d98af62-7f81-404b-85a2-08efb1650fef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d98af62-7f81-404b-85a2-08efb1650fef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the `source` field preprocessing logic to use a shared utility helper for consistent empty value handling across the codebase. This improves code maintainability and ensures uniform treatment of empty or missing values during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->