### PR TITLE
Fix broken post-create object details transition

### DIFF
--- a/src/lib/components/objectDetails/editMode/form.svelte
+++ b/src/lib/components/objectDetails/editMode/form.svelte
@@ -183,8 +183,10 @@
     }
 
     function handleSaveSuccess(id: Id<'objects'>) {
+        activeObject.isDirty = false;
         activeObject.isEditing = false;
-        // in case we were creating a new object
+        activeObject.isLoading = true;
+        activeObject.detailsId = id;
         goto(`/object/${id}`);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the active object state aligned with the newly created object id before redirecting away from the create form
- preserve the expected loading transition while the details overlay fetches the newly created object
- clear the dirty flag after a successful save so the post-create view opens cleanly

## Testing
- `PUBLIC_CONVEX_URL=https://example.convex.cloud bun run check` *(passes with existing warnings only)*
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d19c3b0-795c-4c97-8d9f-7f2be1565808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d19c3b0-795c-4c97-8d9f-7f2be1565808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form save behavior by properly updating object state after saving, including clearing dirty flags and setting correct loading states before navigating to the updated object details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->