### PR TITLE
Rewrite README with actual project information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,82 @@
-# create-svelte
+# Радиоателье. Архив
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/main/packages/create-svelte).
+A web application for documenting and archiving old signs and storefronts. Users can discover, catalog, and share information about historical signage through an interactive map interface.
 
-## Creating a project
+## Tech Stack
 
-If you're seeing this, you've probably already done this step. Congrats!
+- **Frontend**: SvelteKit 2 + Svelte 5, Tailwind CSS 4, Bits UI
+- **Backend**: Convex (serverless functions + database)
+- **Auth**: Clerk (JWT-based, with SSO support)
+- **Maps**: Google Maps API, Deck.gl
+- **Search**: Typesense (full-text + geospatial)
+- **Package Manager**: Bun
 
-```bash
-# create a new project in the current directory
-npm create svelte@latest
+## Prerequisites
 
-# create a new project in my-app
-npm create svelte@latest my-app
+- Bun >= 1.3.8 (or Node.js >= 22.9.0)
+- A running Convex project
+- Clerk application
+- Typesense instance
+- Google Maps API key
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   bun install
+   ```
+
+2. Copy the environment file and fill in your credentials:
+   ```bash
+   cp .env.local.example .env.local
+   ```
+
+   Required environment variables:
+   - `CLERK_JWT_ISSUER_DOMAIN` — Clerk JWT issuer URL
+   - `CLERK_WEBHOOK_SECRET` — Clerk webhook signing secret
+   - `TYPESENSE_*` — Typesense host, port, protocol, and API key
+   - `PUBLIC_GOOGLE_MAPS_API_KEY` — Google Maps API key
+
+3. Start the development environment (runs Convex + Vite concurrently):
+   ```bash
+   bun run dev
+   ```
+
+## Key Scripts
+
+| Command | Description |
+|---|---|
+| `bun run dev` | Start dev server (Convex + Vite) |
+| `bun run check` | Type-check with `svelte-check` |
+| `bun run lint` | Lint and auto-fix with ESLint |
+| `bun run format` | Format with Prettier (Tailwind class sorting) |
+
+## Project Structure
+
+```
+src/
+├── routes/
+│   ├── (app)/          # Main app (authenticated)
+│   │   └── (fullList)/ # List + detail views, object creation, import
+│   └── login/          # Auth pages (login, SSO, password reset)
+├── lib/
+│   ├── components/     # UI components (map, search, forms, etc.)
+│   ├── schema/         # Zod validation schemas
+│   └── interfaces/     # TypeScript type definitions
+└── convex/             # Serverless backend
+    ├── schema.ts       # Database schema
+    ├── objects.ts      # Object CRUD
+    ├── markers.ts      # Map markers
+    ├── search.ts       # Typesense search
+    ├── users.ts        # User management
+    ├── imports.ts      # CSV import logic
+    └── ...
 ```
 
-## Developing
+## Features
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-To create a production version of your app:
-
-```bash
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+- **Interactive map** — Google Maps + Deck.gl layers, Street View integration, marker clustering
+- **Object archive** — Create and manage archive entries with location, metadata, categories, tags, and images
+- **Search** — Full-text search via Typesense, with Google Places integration for address lookup
+- **Data import** — CSV import with field mapping, validation, and batch processing
+- **User accounts** — Clerk authentication, role-based access, personal (private) tags and visited markers tracking

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Радиоателье. Архив
+# Radioatelier. Archive
 
-A web application for documenting and archiving old signs and storefronts. Users can discover, catalog, and share information about historical signage through an interactive map interface.
+A web app for documenting and archiving urban details (old signs, plaques, mosaics, etc) where users can store, see and share info about items they find.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Radioatelier. Archive
 
-A web app for documenting and archiving urban details (old signs, plaques, mosaics, etc) where users can store, see and share info about items they find.
+An archive of urban artifacts — old signs, plaques, mosaics, and other details found on city streets. Users can add items to an interactive map, attach photos and metadata, view, search and share points with others.
 
 ## Prerequisites
 
-- Bun >= 1.3.8 (or Node.js >= 22.9.0)
+- Node.js >= 22.9.0
+- Bun >= 1.3.8 as a package manager
 - A running Convex project
 - Clerk application
 - Typesense instance
@@ -13,16 +14,19 @@ A web app for documenting and archiving urban details (old signs, plaques, mosai
 ## Getting Started
 
 1. Install dependencies:
+
    ```bash
    bun install
    ```
 
 2. Copy the environment file and fill in your credentials:
+
    ```bash
    cp .env.local.example .env.local
    ```
 
 3. Start the development environment (runs Convex + Vite concurrently):
+
    ```bash
    bun run dev
    ```
@@ -30,7 +34,7 @@ A web app for documenting and archiving urban details (old signs, plaques, mosai
 ## Key Scripts
 
 | Command | Description |
-|---|---|
+| --- | --- |
 | `bun run dev` | Start dev server (Convex + Vite) |
 | `bun run check` | Type-check with `svelte-check` |
 | `bun run lint` | Lint and auto-fix with ESLint |
@@ -38,8 +42,8 @@ A web app for documenting and archiving urban details (old signs, plaques, mosai
 
 ## Features
 
-- **Interactive map** — Google Maps + Deck.gl layers, Street View integration, marker clustering
+- **Interactive map** — Google Maps + Deck.gl layers, Street View integration
 - **Object archive** — Create and manage archive entries with location, metadata, categories, tags, and images
-- **Search** — Full-text search via Typesense, with Google Places integration for address lookup
-- **Data import** — CSV import with field mapping, validation, and batch processing
+- **Search** — Full-text search via Typesense and Google Places
+- **Data import** — CSV import to migrate data from other sources
 - **User accounts** — Clerk authentication, role-based access, personal (private) tags and visited markers tracking

--- a/README.md
+++ b/README.md
@@ -2,15 +2,6 @@
 
 A web application for documenting and archiving old signs and storefronts. Users can discover, catalog, and share information about historical signage through an interactive map interface.
 
-## Tech Stack
-
-- **Frontend**: SvelteKit 2 + Svelte 5, Tailwind CSS 4, Bits UI
-- **Backend**: Convex (serverless functions + database)
-- **Auth**: Clerk (JWT-based, with SSO support)
-- **Maps**: Google Maps API, Deck.gl
-- **Search**: Typesense (full-text + geospatial)
-- **Package Manager**: Bun
-
 ## Prerequisites
 
 - Bun >= 1.3.8 (or Node.js >= 22.9.0)
@@ -31,12 +22,6 @@ A web application for documenting and archiving old signs and storefronts. Users
    cp .env.local.example .env.local
    ```
 
-   Required environment variables:
-   - `CLERK_JWT_ISSUER_DOMAIN` — Clerk JWT issuer URL
-   - `CLERK_WEBHOOK_SECRET` — Clerk webhook signing secret
-   - `TYPESENSE_*` — Typesense host, port, protocol, and API key
-   - `PUBLIC_GOOGLE_MAPS_API_KEY` — Google Maps API key
-
 3. Start the development environment (runs Convex + Vite concurrently):
    ```bash
    bun run dev
@@ -50,28 +35,6 @@ A web application for documenting and archiving old signs and storefronts. Users
 | `bun run check` | Type-check with `svelte-check` |
 | `bun run lint` | Lint and auto-fix with ESLint |
 | `bun run format` | Format with Prettier (Tailwind class sorting) |
-
-## Project Structure
-
-```
-src/
-├── routes/
-│   ├── (app)/          # Main app (authenticated)
-│   │   └── (fullList)/ # List + detail views, object creation, import
-│   └── login/          # Auth pages (login, SSO, password reset)
-├── lib/
-│   ├── components/     # UI components (map, search, forms, etc.)
-│   ├── schema/         # Zod validation schemas
-│   └── interfaces/     # TypeScript type definitions
-└── convex/             # Serverless backend
-    ├── schema.ts       # Database schema
-    ├── objects.ts      # Object CRUD
-    ├── markers.ts      # Map markers
-    ├── search.ts       # Typesense search
-    ├── users.ts        # User management
-    ├── imports.ts      # CSV import logic
-    └── ...
-```
 
 ## Features
 


### PR DESCRIPTION
Replace the default create-svelte template README with relevant
documentation covering the project's purpose, tech stack, setup
instructions, project structure, and key features.

https://claude.ai/code/session_01XfipTz14V4nVcMAyzv3Unv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote README into a domain-specific "Radioatelier. Archive" guide with streamlined setup using Bun (and Node.js guidance), environment setup, and run commands.
  * Added a "Key Scripts" table (check, lint, format).
  * Documented product features: interactive maps & Street View, object archive, search, CSV import, and authenticated user accounts with private tags and visit tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->