### PR TITLE
Refactor map module to use provider abstraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "archive",

--- a/src/convex/_generated/dataModel.d.ts
+++ b/src/convex/_generated/dataModel.d.ts
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /**
  * Generated data model types.
  *

--- a/src/convex/_generated/dataModel.d.ts
+++ b/src/convex/_generated/dataModel.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated data model types.
  *

--- a/src/convex/_generated/server.d.ts
+++ b/src/convex/_generated/server.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
  *

--- a/src/convex/_generated/server.d.ts
+++ b/src/convex/_generated/server.d.ts
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
  *

--- a/src/lib/components/input/combobox.svelte
+++ b/src/lib/components/input/combobox.svelte
@@ -9,7 +9,7 @@
     } from '$lib/components/ui/command';
     import CheckIcon from '@lucide/svelte/icons/check';
     import PlusIcon from '@lucide/svelte/icons/plus';
-    import ComboboxTrigger from './combobox/comboboxTrigger.svelte';
+    import ComboboxTrigger from '$lib/components/input/combobox/comboboxTrigger.svelte';
     import type {Option} from '$lib/interfaces/option';
     type ComboboxValue = string | string[] | null | undefined;
 

--- a/src/lib/components/input/imageUpload/index.svelte
+++ b/src/lib/components/input/imageUpload/index.svelte
@@ -4,7 +4,7 @@
     import CropDialog from '$lib/components/input/imageUpload/cropDialog.svelte';
     import ImageViewer from '$lib/components/input/imageUpload/imageViewer.svelte';
     import {toast} from 'svelte-sonner';
-    import LoadingOverlay from './loadingOverlay.svelte';
+    import LoadingOverlay from '$lib/components/input/imageUpload/loadingOverlay.svelte';
     import TrashIcon from '@lucide/svelte/icons/trash-2';
     import UploadIcon from '@lucide/svelte/icons/upload';
 

--- a/src/lib/components/map/locationMarker.svelte
+++ b/src/lib/components/map/locationMarker.svelte
@@ -2,6 +2,7 @@
     import MarkerIcon from '$lib/components/map/markerIcon.svelte';
     import {onMount, onDestroy} from 'svelte';
     import {mapState} from '$lib/state/map.svelte';
+    import type {IMarkerHandle} from '$lib/interfaces/map';
     import DotIcon from '@lucide/svelte/icons/dot';
     import {mount, unmount} from 'svelte';
 
@@ -15,7 +16,7 @@
 
     let {orientationEnabled}: Props = $props();
 
-    let marker: google.maps.marker.AdvancedMarkerElement | undefined = $state();
+    let handle: IMarkerHandle | undefined = $state();
     let markerIcon: ReturnType<typeof mount> | undefined;
     let updateLocationInterval: ReturnType<typeof setInterval> | undefined;
 
@@ -30,16 +31,13 @@
             },
         });
 
-        const {AdvancedMarkerElement, CollisionBehavior} =
-            await mapState.loader.importLibrary('marker');
+        await mapState.provider.preloadMarkerLibrary();
 
-        marker = new AdvancedMarkerElement({
-            map: mapState.map,
-            content: icon,
-            collisionBehavior: CollisionBehavior.REQUIRED,
-            gmpClickable: false,
+        handle = mapState.provider.createMarkerHandle({lat: 0, lng: 0}, icon, {
             zIndex: 10,
+            clickable: false,
         });
+        handle.show();
 
         updateCurrentPosition(true);
         updateLocationInterval = setInterval(updateCurrentPosition, 1000);
@@ -52,19 +50,21 @@
         if (markerIcon) {
             unmount(markerIcon);
         }
+        handle?.remove();
     });
 
     function handleOrientation(event: DeviceOrientationEventExtended) {
-        if (!marker) {
+        const element = handle?.getElement();
+        if (!element) {
             return;
         }
 
         const degrees = event.webkitCompassHeading ? event.webkitCompassHeading : event.alpha;
-        (marker.content as HTMLElement).style.rotate = `${degrees}deg`;
+        element.style.rotate = `${degrees}deg`;
     }
 
     function updateCurrentPosition(forceStale = false) {
-        if (!marker) {
+        if (!handle) {
             return;
         }
 
@@ -73,26 +73,24 @@
             position = JSON.parse(localStorage.getItem('lastPosition') as string);
         }
 
-        marker.position = {lat: position.lat, lng: position.lng};
+        handle.setPosition({lat: position.lat, lng: position.lng});
+        const element = handle.getElement();
         if (!position.isCurrent || forceStale) {
-            (marker.content as HTMLDivElement).classList.add('nav-marker-stale');
-            (marker.content as HTMLDivElement).classList.add('nav-marker-oriented-stale');
+            element?.classList.add('nav-marker-stale');
+            element?.classList.add('nav-marker-oriented-stale');
         } else {
-            (marker.content as HTMLDivElement).classList.remove('nav-marker-stale');
-            (marker.content as HTMLDivElement).classList.remove('nav-marker-oriented-stale');
+            element?.classList.remove('nav-marker-stale');
+            element?.classList.remove('nav-marker-oriented-stale');
         }
     }
 
     $effect(() => {
+        const element = handle?.getElement();
         if (orientationEnabled) {
-            if (marker && marker.content) {
-                (marker.content as HTMLDivElement).classList.add('nav-marker-oriented');
-            }
+            element?.classList.add('nav-marker-oriented');
             window.addEventListener('deviceorientation', handleOrientation, true);
         } else {
-            if (marker && marker.content) {
-                (marker.content as HTMLDivElement).classList.remove('nav-marker-oriented');
-            }
+            element?.classList.remove('nav-marker-oriented');
             window.removeEventListener('deviceorientation', handleOrientation, true);
         }
     });

--- a/src/lib/components/map/locationMarker.svelte
+++ b/src/lib/components/map/locationMarker.svelte
@@ -2,7 +2,7 @@
     import MarkerIcon from '$lib/components/map/markerIcon.svelte';
     import {onMount, onDestroy} from 'svelte';
     import {mapState} from '$lib/state/map.svelte';
-    import type {IMarkerHandle} from '$lib/interfaces/map';
+    import type {MarkerHandle} from '$lib/interfaces/map';
     import DotIcon from '@lucide/svelte/icons/dot';
     import {mount, unmount} from 'svelte';
 
@@ -16,7 +16,7 @@
 
     let {orientationEnabled}: Props = $props();
 
-    let handle: IMarkerHandle | undefined = $state();
+    let handle: MarkerHandle | undefined = $state();
     let markerIcon: ReturnType<typeof mount> | undefined;
     let updateLocationInterval: ReturnType<typeof setInterval> | undefined;
 

--- a/src/lib/components/map/locationMarker.svelte
+++ b/src/lib/components/map/locationMarker.svelte
@@ -31,9 +31,9 @@
             },
         });
 
-        await mapState.provider.preloadMarkerLibrary();
+        await mapState.provider!.preloadMarkerLibrary();
 
-        handle = mapState.provider.createMarkerHandle({lat: 0, lng: 0}, icon, {
+        handle = mapState.provider!.createMarkerHandle({lat: 0, lng: 0}, icon, {
             zIndex: 10,
             clickable: false,
         });

--- a/src/lib/components/map/map.svelte
+++ b/src/lib/components/map/map.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import {onMount, onDestroy} from 'svelte';
     import {mapState} from '$lib/state/map.svelte';
-    import type {IMapProvider} from '$lib/interfaces/map';
+    import type {MapProvider} from '$lib/interfaces/map';
     import type {Location} from '$lib/interfaces/location';
     import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
     import {MarkerManager} from '$lib/services/map/markerManager';
@@ -14,7 +14,7 @@
     } from '$lib/services/map/geolocation';
     import {PointerDragZoomController} from '$lib/services/map/pointerDragZoom';
     import config from '$lib/config';
-    import StreetView from './streetView.svelte';
+    import StreetView from '$lib/components/map/streetView.svelte';
     import {removeDragTimeout} from '$lib/state/marker.svelte';
 
     interface Props {
@@ -78,7 +78,7 @@
         }
     });
 
-    async function initMarkerManager(provider: IMapProvider): Promise<MarkerManager> {
+    async function initMarkerManager(provider: MapProvider): Promise<MarkerManager> {
         const initialMode = shouldUseDeck(provider) ? 'deck' : 'dom';
         const manager = new MarkerManager(
             provider,
@@ -99,10 +99,8 @@
     }
 
     function handleIdle() {
-        const mode = mapState.markerManager?.setRendererMode(
-            shouldUseDeck(mapState.provider!) ? 'deck' : 'dom',
-        );
-        mapState.deckEnabled = mode === 'deck';
+        mapState.markerManager?.setRendererMode(shouldUseDeck(mapState.provider!) ? 'deck' : 'dom');
+        mapState.deckEnabled = mapState.markerManager?.isDeckRenderer ?? false;
         mapState.markerManager?.scheduleViewportUpdate();
     }
 
@@ -128,7 +126,7 @@
         );
     }
 
-    function shouldUseDeck(provider: IMapProvider): boolean {
+    function shouldUseDeck(provider: MapProvider): boolean {
         return provider.getZoom() <= config.deckZoomThreshold;
     }
 

--- a/src/lib/components/map/map.svelte
+++ b/src/lib/components/map/map.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import {onMount, onDestroy} from 'svelte';
     import {mapState} from '$lib/state/map.svelte';
+    import type {IMapProvider} from '$lib/interfaces/map';
     import type {Location} from '$lib/interfaces/location';
+    import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
     import {MarkerManager} from '$lib/services/map/markerManager';
     import {DomMarkerRenderer} from '$lib/services/map/renderer/domMarkerRenderer';
-    import {
-        HybridMarkerRenderer,
-    } from '$lib/services/map/providers/google/hybridMarkerRenderer';
+    import {HybridMarkerRenderer} from '$lib/services/map/providers/google/hybridMarkerRenderer';
     import {
         getInitialCenter,
         startPositionPolling,
@@ -36,9 +36,11 @@
         positionInterval = startPositionPolling(5000);
 
         try {
+            const provider = new GoogleMapsProvider();
             const center = await getInitialCenter();
-            await mapState.provider.initialize(container!, center);
-            mapState.markerManager = await initMarkerManager();
+            await provider.initialize(container!, center);
+            mapState.provider = provider;
+            mapState.markerManager = await initMarkerManager(provider);
             mapState.isReady = true;
             mapState.markerManager.scheduleViewportUpdate();
         } catch (e) {
@@ -50,8 +52,8 @@
             initListeners();
 
             new PointerDragZoomController({
-                getZoom: () => mapState.provider.getZoom(),
-                setZoom: zoom => mapState.provider.setZoom(zoom),
+                getZoom: () => mapState.provider!.getZoom(),
+                setZoom: zoom => mapState.provider!.setZoom(zoom),
                 onStart: () => {
                     clearTimeout(clickTimeout);
                     clickTimeout = undefined;
@@ -67,9 +69,8 @@
         }
     });
 
-    async function initMarkerManager(): Promise<MarkerManager> {
-        const provider = mapState.provider;
-        const initialMode = shouldUseDeck() ? 'deck' : 'dom';
+    async function initMarkerManager(provider: IMapProvider): Promise<MarkerManager> {
+        const initialMode = shouldUseDeck(provider) ? 'deck' : 'dom';
         const manager = new MarkerManager(
             provider,
             mode =>
@@ -83,13 +84,15 @@
     }
 
     function initListeners() {
-        unsubIdle = mapState.provider.onIdle(handleIdle);
-        unsubClick = mapState.provider.onClick(handleClick);
-        unsubCenterChanged = mapState.provider.onCenterChanged(handleCenterChanged);
+        unsubIdle = mapState.provider!.onIdle(handleIdle);
+        unsubClick = mapState.provider!.onClick(handleClick);
+        unsubCenterChanged = mapState.provider!.onCenterChanged(handleCenterChanged);
     }
 
     function handleIdle() {
-        const mode = mapState.markerManager?.setRendererMode(shouldUseDeck() ? 'deck' : 'dom');
+        const mode = mapState.markerManager?.setRendererMode(
+            shouldUseDeck(mapState.provider!) ? 'deck' : 'dom',
+        );
         mapState.deckEnabled = mode === 'deck';
         mapState.markerManager?.scheduleViewportUpdate();
     }
@@ -116,8 +119,8 @@
         );
     }
 
-    function shouldUseDeck(): boolean {
-        return mapState.provider.getZoom() <= config.deckZoomThreshold;
+    function shouldUseDeck(provider: IMapProvider): boolean {
+        return provider.getZoom() <= config.deckZoomThreshold;
     }
 
     onDestroy(() => {
@@ -129,7 +132,8 @@
         unsubClick?.();
         unsubCenterChanged?.();
         mapState.markerManager?.destroy();
-        mapState.provider.destroy();
+        mapState.provider?.destroy();
+        mapState.provider = null;
         mapState.isReady = false;
     });
 </script>

--- a/src/lib/components/map/map.svelte
+++ b/src/lib/components/map/map.svelte
@@ -3,6 +3,10 @@
     import {mapState} from '$lib/state/map.svelte';
     import type {Location} from '$lib/interfaces/location';
     import {MarkerManager} from '$lib/services/map/markerManager';
+    import {DomMarkerRenderer} from '$lib/services/map/renderer/domMarkerRenderer';
+    import {
+        HybridMarkerRenderer,
+    } from '$lib/services/map/providers/google/hybridMarkerRenderer';
     import {
         getInitialCenter,
         startPositionPolling,
@@ -10,7 +14,6 @@
     } from '$lib/services/map/geolocation';
     import {PointerDragZoomController} from '$lib/services/map/pointerDragZoom';
     import config from '$lib/config';
-    import {themeState} from '$lib/state/theme.svelte';
     import StreetView from './streetView.svelte';
     import {removeDragTimeout} from '$lib/state/marker.svelte';
 
@@ -25,14 +28,19 @@
     let positionInterval: number | undefined;
     let isInZoomMode = false;
 
+    let unsubIdle: (() => void) | undefined;
+    let unsubClick: (() => void) | undefined;
+    let unsubCenterChanged: (() => void) | undefined;
+
     onMount(async () => {
         positionInterval = startPositionPolling(5000);
 
         try {
-            const mapInstance = await initMap();
-            mapState.markerManager = await initMarkerManager(mapInstance);
-            mapState.map = mapInstance;
-            mapState.markerManager!.scheduleViewportUpdate();
+            const center = await getInitialCenter();
+            await mapState.provider.initialize(container!, center);
+            mapState.markerManager = await initMarkerManager();
+            mapState.isReady = true;
+            mapState.markerManager.scheduleViewportUpdate();
         } catch (e) {
             console.error('error instantiating map');
             console.error(e);
@@ -42,8 +50,8 @@
             initListeners();
 
             new PointerDragZoomController({
-                getZoom: () => mapState.map?.getZoom() ?? 15,
-                setZoom: zoom => mapState.map?.setZoom(zoom),
+                getZoom: () => mapState.provider.getZoom(),
+                setZoom: zoom => mapState.provider.setZoom(zoom),
                 onStart: () => {
                     clearTimeout(clickTimeout);
                     clickTimeout = undefined;
@@ -59,105 +67,57 @@
         }
     });
 
-    async function initMap(): Promise<google.maps.Map> {
-        const [{Map}, {ColorScheme}] = await Promise.all([
-            mapState.loader.importLibrary('maps'),
-            mapState.loader.importLibrary('core'),
-        ]);
-
-        const center = await getInitialCenter();
-
-        return new Map(container!, {
-            zoom: center.zoom ?? 15,
-            center,
-            mapId: config.googleMapsId,
-            controlSize: 40,
-            mapTypeControl: false,
-            cameraControl: false,
-            fullscreenControl: false,
-            zoomControl: false,
-            clickableIcons: false,
-            colorScheme: getMapColorScheme(ColorScheme),
-        });
-    }
-
-    function getMapColorScheme(
-        ColorScheme: typeof google.maps.ColorScheme,
-    ): google.maps.ColorScheme {
-        if (themeState.preference === 'system') {
-            return ColorScheme.FOLLOW_SYSTEM;
-        }
-
-        return themeState.resolved === 'dark' ? ColorScheme.DARK : ColorScheme.LIGHT;
-    }
-
-    async function initMarkerManager(mapInstance: google.maps.Map): Promise<MarkerManager> {
-        const manager = new MarkerManager(mapInstance, {
-            renderer: shouldUseDeck(mapInstance) ? 'deck' : 'dom',
-        });
-        await manager.initialize(mapState.loader);
+    async function initMarkerManager(): Promise<MarkerManager> {
+        const provider = mapState.provider;
+        const initialMode = shouldUseDeck() ? 'deck' : 'dom';
+        const manager = new MarkerManager(
+            provider,
+            mode =>
+                mode === 'deck'
+                    ? new HybridMarkerRenderer(provider)
+                    : new DomMarkerRenderer(provider),
+            {renderer: initialMode},
+        );
+        await manager.initialize();
         return manager;
     }
 
     function initListeners() {
-        if (!mapState.map) {
-            return;
-        }
-
-        google.maps.event.addListener(mapState.map, 'idle', handleIdle);
-        google.maps.event.addListener(mapState.map, 'click', handleClick);
-        google.maps.event.addListener(mapState.map, 'center_changed', handleCenterChanged);
+        unsubIdle = mapState.provider.onIdle(handleIdle);
+        unsubClick = mapState.provider.onClick(handleClick);
+        unsubCenterChanged = mapState.provider.onCenterChanged(handleCenterChanged);
     }
 
     function handleIdle() {
-        mapState.markerManager?.setRendererMode(shouldUseDeck(mapState.map!) ? 'deck' : 'dom');
+        const mode = mapState.markerManager?.setRendererMode(shouldUseDeck() ? 'deck' : 'dom');
+        mapState.deckEnabled = mode === 'deck';
         mapState.markerManager?.scheduleViewportUpdate();
     }
 
-    function handleClick(event: google.maps.MapMouseEvent) {
+    function handleClick(latLng: {lat: number; lng: number}) {
         if (mapState.deckEnabled || isInZoomMode) {
             return;
         }
 
         clickTimeout = setTimeout(() => {
             if (!isInZoomMode && onClick) {
-                onClick({
-                    lat: event.latLng?.lat() ?? 0,
-                    lng: event.latLng?.lng() ?? 0,
-                });
+                onClick(latLng);
             }
             clickTimeout = undefined;
         }, 300);
     }
 
-    function handleCenterChanged() {
-        if (!mapState.map) {
-            return;
-        }
-
+    function handleCenterChanged(center: {lat: number; lng: number}, zoom: number) {
         removeDragTimeout();
 
-        const center = mapState.map.getCenter();
         localStorage.setItem(
             'lastCenter',
-            JSON.stringify({
-                lat: (center as google.maps.LatLng).lat(),
-                lng: (center as google.maps.LatLng).lng(),
-                zoom: mapState.map.getZoom(),
-            }),
+            JSON.stringify({lat: center.lat, lng: center.lng, zoom}),
         );
     }
 
-    function cleanupListeners() {
-        if (!mapState.map) {
-            return;
-        }
-
-        google.maps.event.clearInstanceListeners(mapState.map);
-    }
-
-    function shouldUseDeck(map: google.maps.Map): boolean {
-        return (map.getZoom() ?? 15) <= config.deckZoomThreshold;
+    function shouldUseDeck(): boolean {
+        return mapState.provider.getZoom() <= config.deckZoomThreshold;
     }
 
     onDestroy(() => {
@@ -165,9 +125,12 @@
             stopPositionPolling(positionInterval);
         }
 
-        cleanupListeners();
+        unsubIdle?.();
+        unsubClick?.();
+        unsubCenterChanged?.();
         mapState.markerManager?.destroy();
-        mapState.map = undefined;
+        mapState.provider.destroy();
+        mapState.isReady = false;
     });
 </script>
 

--- a/src/lib/components/map/map.svelte
+++ b/src/lib/components/map/map.svelte
@@ -32,37 +32,46 @@
     let unsubClick: (() => void) | undefined;
     let unsubCenterChanged: (() => void) | undefined;
 
+    async function setupProviderAndMarkers() {
+        const provider = new GoogleMapsProvider();
+        const center = await getInitialCenter();
+        await provider.initialize(container!, center);
+        mapState.provider = provider;
+        mapState.markerManager = await initMarkerManager(provider);
+        mapState.deckEnabled = mapState.markerManager.isDeckRenderer;
+        mapState.isReady = true;
+        mapState.markerManager.scheduleViewportUpdate();
+    }
+
+    function setupListenersAndGestures() {
+        initListeners();
+
+        new PointerDragZoomController({
+            getZoom: () => mapState.provider!.getZoom(),
+            setZoom: zoom => mapState.provider!.setZoom(zoom),
+            onStart: () => {
+                clearTimeout(clickTimeout);
+                clickTimeout = undefined;
+                isInZoomMode = true;
+            },
+            onEnd: () => {
+                isInZoomMode = false;
+            },
+        }).attachDoubleTapDragZoom(container!);
+    }
+
     onMount(async () => {
         positionInterval = startPositionPolling(5000);
 
         try {
-            const provider = new GoogleMapsProvider();
-            const center = await getInitialCenter();
-            await provider.initialize(container!, center);
-            mapState.provider = provider;
-            mapState.markerManager = await initMarkerManager(provider);
-            mapState.isReady = true;
-            mapState.markerManager.scheduleViewportUpdate();
+            await setupProviderAndMarkers();
         } catch (e) {
             console.error('error instantiating map');
             console.error(e);
         }
 
         try {
-            initListeners();
-
-            new PointerDragZoomController({
-                getZoom: () => mapState.provider!.getZoom(),
-                setZoom: zoom => mapState.provider!.setZoom(zoom),
-                onStart: () => {
-                    clearTimeout(clickTimeout);
-                    clickTimeout = undefined;
-                    isInZoomMode = true;
-                },
-                onEnd: () => {
-                    isInZoomMode = false;
-                },
-            }).attachDoubleTapDragZoom(container!);
+            setupListenersAndGestures();
         } catch (e) {
             console.error('error initialising map event listeners');
             console.error(e);
@@ -134,6 +143,7 @@
         mapState.markerManager?.destroy();
         mapState.provider?.destroy();
         mapState.provider = null;
+        mapState.deckEnabled = false;
         mapState.isReady = false;
     });
 </script>

--- a/src/lib/components/map/positionButton.svelte
+++ b/src/lib/components/map/positionButton.svelte
@@ -12,8 +12,8 @@
             return;
         }
 
-        if (mapState.map) {
-            mapState.map.setCenter(position);
+        if (mapState.isReady) {
+            mapState.provider.setCenter(position.lat, position.lng);
         }
     }
 </script>

--- a/src/lib/components/map/positionButton.svelte
+++ b/src/lib/components/map/positionButton.svelte
@@ -13,6 +13,7 @@
         }
 
         if (mapState.isReady) {
+            mapState.provider!.setZoom(15);
             mapState.provider!.setCenter(position.lat, position.lng);
         }
     }

--- a/src/lib/components/map/positionButton.svelte
+++ b/src/lib/components/map/positionButton.svelte
@@ -13,7 +13,7 @@
         }
 
         if (mapState.isReady) {
-            mapState.provider.setCenter(position.lat, position.lng);
+            mapState.provider!.setCenter(position.lat, position.lng);
         }
     }
 </script>

--- a/src/lib/components/map/streetView.svelte
+++ b/src/lib/components/map/streetView.svelte
@@ -2,7 +2,8 @@
     import StreetViewOverlay from './streetViewOverlay.svelte';
     import {cn} from '$lib/utils';
     import {onDestroy} from 'svelte';
-    import {mapState, getGoogleProvider} from '$lib/state/map.svelte';
+    import {mapState} from '$lib/state/map.svelte';
+    import {getGoogleProvider} from '$lib/services/map/providers/google/provider';
     import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
     let streetViewContainer: HTMLDivElement | undefined = $state();

--- a/src/lib/components/map/streetView.svelte
+++ b/src/lib/components/map/streetView.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-    import StreetViewOverlay from './streetViewOverlay.svelte';
+    import StreetViewOverlay from '$lib/components/map/streetViewOverlay.svelte';
     import {cn} from '$lib/utils';
     import {onDestroy} from 'svelte';
     import {mapState} from '$lib/state/map.svelte';
-    import {getGoogleProvider} from '$lib/services/map/providers/google/provider';
+    import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
     import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
     let streetViewContainer: HTMLDivElement | undefined = $state();
@@ -26,7 +26,11 @@
             throw new Error('Prerequisites for Street View instantiation are not met');
         }
 
-        const provider = getGoogleProvider();
+        const provider = mapState.provider;
+        if (!(provider instanceof GoogleMapsProvider)) {
+            return;
+        }
+
         const {StreetViewPanorama} = await provider.loader.importLibrary('streetView');
 
         const googleMap = provider.getGoogleMap();

--- a/src/lib/components/map/streetView.svelte
+++ b/src/lib/components/map/streetView.svelte
@@ -28,6 +28,11 @@
         const provider = getGoogleProvider();
         const {StreetViewPanorama} = await provider.loader.importLibrary('streetView');
 
+        const googleMap = provider.getGoogleMap();
+        if (!googleMap) {
+            throw new Error('Google Maps instance not available for Street View');
+        }
+
         panorama = new StreetViewPanorama(streetViewContainer, {
             visible: false,
             addressControl: false,
@@ -39,8 +44,7 @@
             zoomControl: false,
         });
 
-        provider.getGoogleMap()?.setStreetView(panorama);
-
+        googleMap.setStreetView(panorama);
         addListeners();
     }
 

--- a/src/lib/components/map/streetView.svelte
+++ b/src/lib/components/map/streetView.svelte
@@ -2,7 +2,7 @@
     import StreetViewOverlay from './streetViewOverlay.svelte';
     import {cn} from '$lib/utils';
     import {onDestroy} from 'svelte';
-    import {mapState} from '$lib/state/map.svelte';
+    import {mapState, getGoogleProvider} from '$lib/state/map.svelte';
     import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
     let streetViewContainer: HTMLDivElement | undefined = $state();
@@ -13,7 +13,7 @@
 
     let instantiated = false;
     $effect(() => {
-        if (mapState.map && !instantiated) {
+        if (mapState.isReady && !instantiated) {
             createStreetView()
                 .then(() => (instantiated = true))
                 .catch(error => console.error(error));
@@ -21,11 +21,12 @@
     });
 
     async function createStreetView() {
-        if (!mapState.map || !streetViewContainer) {
+        if (!mapState.isReady || !streetViewContainer) {
             throw new Error('Prerequisites for Street View instantiation are not met');
         }
 
-        const {StreetViewPanorama} = await mapState.loader.importLibrary('streetView');
+        const provider = getGoogleProvider();
+        const {StreetViewPanorama} = await provider.loader.importLibrary('streetView');
 
         panorama = new StreetViewPanorama(streetViewContainer, {
             visible: false,
@@ -38,7 +39,7 @@
             zoomControl: false,
         });
 
-        mapState.map.setStreetView(panorama);
+        provider.getGoogleMap()?.setStreetView(panorama);
 
         addListeners();
     }

--- a/src/lib/components/map/streetViewOverlay.svelte
+++ b/src/lib/components/map/streetViewOverlay.svelte
@@ -3,7 +3,7 @@
     import config from '$lib/config';
     import {cn} from '$lib/utils';
     import Button from '../ui/button/button.svelte';
-    import {getGoogleProvider} from '$lib/state/map.svelte';
+    import {getGoogleProvider} from '$lib/services/map/providers/google/provider';
     import XMarkIcon from '@lucide/svelte/icons/x';
 
     interface Props {

--- a/src/lib/components/map/streetViewOverlay.svelte
+++ b/src/lib/components/map/streetViewOverlay.svelte
@@ -2,8 +2,9 @@
     import {onDestroy} from 'svelte';
     import config from '$lib/config';
     import {cn} from '$lib/utils';
-    import Button from '../ui/button/button.svelte';
-    import {getGoogleProvider} from '$lib/services/map/providers/google/provider';
+    import Button from '$lib/components/ui/button/button.svelte';
+    import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
+    import {mapState} from '$lib/state/map.svelte';
     import XMarkIcon from '@lucide/svelte/icons/x';
 
     interface Props {
@@ -48,7 +49,11 @@
             return;
         }
 
-        const provider = getGoogleProvider();
+        const provider = mapState.provider;
+        if (!(provider instanceof GoogleMapsProvider)) {
+            return;
+        }
+
         const [{Map}, {AdvancedMarkerElement}] = await Promise.all([
             provider.loader.importLibrary('maps'),
             provider.loader.importLibrary('marker'),

--- a/src/lib/components/map/streetViewOverlay.svelte
+++ b/src/lib/components/map/streetViewOverlay.svelte
@@ -3,7 +3,7 @@
     import config from '$lib/config';
     import {cn} from '$lib/utils';
     import Button from '../ui/button/button.svelte';
-    import {mapState} from '$lib/state/map.svelte';
+    import {getGoogleProvider} from '$lib/state/map.svelte';
     import XMarkIcon from '@lucide/svelte/icons/x';
 
     interface Props {
@@ -48,11 +48,12 @@
             return;
         }
 
+        const provider = getGoogleProvider();
         const [{Map}, {AdvancedMarkerElement}] = await Promise.all([
-            mapState.loader.importLibrary('maps'),
-            mapState.loader.importLibrary('marker'),
+            provider.loader.importLibrary('maps'),
+            provider.loader.importLibrary('marker'),
         ]);
-        const center = position ?? mapState.map?.getCenter() ?? undefined;
+        const center = position ?? provider.getCenter() ?? undefined;
 
         miniMap = new Map(miniMapContainer, {
             mapId: config.googleMapsId,

--- a/src/lib/components/objectDetails/objectDetails.svelte
+++ b/src/lib/components/objectDetails/objectDetails.svelte
@@ -6,8 +6,8 @@
     import {Button} from '$lib/components/ui/button';
     import {badgeVariants} from '$lib/components/ui/badge';
     import {toast} from 'svelte-sonner';
-    import CloseButton from './closeButton.svelte';
-    import Background from './background.svelte';
+    import CloseButton from '$lib/components/objectDetails/closeButton.svelte';
+    import Background from '$lib/components/objectDetails/background.svelte';
     import {mapState} from '$lib/state/map.svelte';
     import {cn} from '$lib/utils.ts';
     import {
@@ -22,7 +22,7 @@
     import {getActiveSearchUrl} from '$lib/state/search.svelte';
     import {setCreateDraftPosition} from '$lib/state/createDraft.svelte';
     import EditMode from '$lib/components/objectDetails/editMode/editMode.svelte';
-    import ViewMode from './viewMode/viewMode.svelte';
+    import ViewMode from '$lib/components/objectDetails/viewMode/viewMode.svelte';
 
     interface Props {
         initialValues?: Partial<LooseObject>;

--- a/src/lib/components/objectDetails/objectDetails.svelte
+++ b/src/lib/components/objectDetails/objectDetails.svelte
@@ -54,8 +54,8 @@
         deactivateMarker();
         clearActiveMarker();
         closeDetailsOverlay();
-        if (mapState.map) {
-            mapState.map.getStreetView().setVisible(false);
+        if (mapState.isReady) {
+            mapState.provider.closeStreetView();
         }
 
         if (ctx.auth.userId) {

--- a/src/lib/components/objectDetails/objectDetails.svelte
+++ b/src/lib/components/objectDetails/objectDetails.svelte
@@ -55,7 +55,7 @@
         clearActiveMarker();
         closeDetailsOverlay();
         if (mapState.isReady) {
-            mapState.provider.closeStreetView();
+            mapState.provider!.closeStreetView();
         }
 
         if (ctx.auth.userId) {

--- a/src/lib/components/search/search.svelte
+++ b/src/lib/components/search/search.svelte
@@ -4,7 +4,7 @@
     import SearchResults from '$lib/components/search/searchResults.svelte';
     import {searchState, applyUrlToSearchState, buildSearchUrl} from '$lib/state/search.svelte';
     import {onDestroy, onMount} from 'svelte';
-    import SearchAreaButton from './searchAreaButton.svelte';
+    import SearchAreaButton from '$lib/components/search/searchAreaButton.svelte';
     import {mapState} from '$lib/state/map.svelte';
     import {page} from '$app/state';
     import {replaceState} from '$app/navigation';

--- a/src/lib/components/search/search.svelte
+++ b/src/lib/components/search/search.svelte
@@ -13,11 +13,11 @@
 
     let centerLat = $state('');
     let centerLng = $state('');
-    let listener: google.maps.MapsEventListener | undefined = $state();
+    let unsubDragEnd: (() => void) | undefined;
 
     onMount(() => {
         updateCenter();
-        listener = mapState.map!.addListener('dragend', updateCenter);
+        unsubDragEnd = mapState.provider.onDragEnd(updateCenter);
 
         const applied = applyUrlToSearchState(page.url);
         if (applied) {
@@ -43,14 +43,14 @@
     });
 
     function updateCenter() {
-        centerLat = mapState.map!.getCenter()!.lat().toString();
-        centerLng = mapState.map!.getCenter()!.lng().toString();
+        const center = mapState.provider.getCenter();
+        if (!center) return;
+        centerLat = center.lat.toString();
+        centerLng = center.lng.toString();
     }
 
     onDestroy(() => {
-        if (listener) {
-            google.maps.event.removeListener(listener);
-        }
+        unsubDragEnd?.();
     });
 </script>
 

--- a/src/lib/components/search/search.svelte
+++ b/src/lib/components/search/search.svelte
@@ -17,7 +17,7 @@
 
     onMount(() => {
         updateCenter();
-        unsubDragEnd = mapState.provider.onDragEnd(updateCenter);
+        unsubDragEnd = mapState.provider!.onDragEnd(updateCenter);
 
         const applied = applyUrlToSearchState(page.url);
         if (applied) {
@@ -43,8 +43,10 @@
     });
 
     function updateCenter() {
-        const center = mapState.provider.getCenter();
-        if (!center) return;
+        const center = mapState.provider!.getCenter();
+        if (!center) {
+            return;
+        }
         centerLat = center.lat.toString();
         centerLng = center.lng.toString();
     }

--- a/src/lib/components/search/searchBar.svelte
+++ b/src/lib/components/search/searchBar.svelte
@@ -25,7 +25,7 @@
         clearTimeout(timeout);
         timeout = window.setTimeout(() => {
             searchState.query = (evt.target as HTMLInputElement).value;
-            const center = mapState.provider.getCenter();
+            const center = mapState.provider?.getCenter();
             if (center) {
                 searchState.lat = center.lat.toString();
                 searchState.lng = center.lng.toString();

--- a/src/lib/components/search/searchBar.svelte
+++ b/src/lib/components/search/searchBar.svelte
@@ -24,14 +24,14 @@
         val = (evt.target as HTMLInputElement).value;
         clearTimeout(timeout);
         timeout = window.setTimeout(() => {
-            const center = mapState.map?.getCenter();
+            const center = mapState.provider.getCenter();
             if (!center) {
                 timeout = undefined;
                 return;
             }
             searchState.query = (evt.target as HTMLInputElement).value;
-            searchState.lat = center.lat().toString();
-            searchState.lng = center.lng().toString();
+            searchState.lat = center.lat.toString();
+            searchState.lng = center.lng.toString();
             timeout = undefined;
         }, 400);
     }

--- a/src/lib/components/search/searchBar.svelte
+++ b/src/lib/components/search/searchBar.svelte
@@ -24,14 +24,12 @@
         val = (evt.target as HTMLInputElement).value;
         clearTimeout(timeout);
         timeout = window.setTimeout(() => {
-            const center = mapState.provider.getCenter();
-            if (!center) {
-                timeout = undefined;
-                return;
-            }
             searchState.query = (evt.target as HTMLInputElement).value;
-            searchState.lat = center.lat.toString();
-            searchState.lng = center.lng.toString();
+            const center = mapState.provider.getCenter();
+            if (center) {
+                searchState.lat = center.lat.toString();
+                searchState.lng = center.lng.toString();
+            }
             timeout = undefined;
         }, 400);
     }

--- a/src/lib/components/search/searchPreviewItem.svelte
+++ b/src/lib/components/search/searchPreviewItem.svelte
@@ -19,8 +19,8 @@
 
         setCenter(object.latitude, object.longitude);
         const marker = object.id ? mapState.markerManager.getMarker(object.id) : null;
-        if (marker?.getRaw()) {
-            google.maps.event.trigger(marker.getRaw()!, 'gmp-click');
+        if (marker) {
+            marker.getOnClick()?.();
         } else if (object.id) {
             objectDetailsOverlay.isMinimized = false;
             objectDetailsOverlay.isDirty = false;

--- a/src/lib/components/search/searchPreviewItem.svelte
+++ b/src/lib/components/search/searchPreviewItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import SearchItemCard from './searchItemCard.svelte';
+    import SearchItemCard from '$lib/components/search/searchItemCard.svelte';
     import {setCenter} from '$lib/services/map/map.svelte';
     import type {SearchItem} from '$lib/interfaces/object';
     import {mapState} from '$lib/state/map.svelte.ts';

--- a/src/lib/components/search/searchResultsItem.svelte
+++ b/src/lib/components/search/searchResultsItem.svelte
@@ -15,9 +15,7 @@
         setCenter(object.latitude, object.longitude);
         if (id && mapState.markerManager) {
             const marker = mapState.markerManager.getMarker(id);
-            if (marker?.getRaw()) {
-                google.maps.event.trigger(marker.getRaw()!, 'gmp-click');
-            }
+            marker?.getOnClick()?.();
         }
     }
 </script>

--- a/src/lib/components/search/searchResultsItem.svelte
+++ b/src/lib/components/search/searchResultsItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import SearchItemCard from './searchItemCard.svelte';
+    import SearchItemCard from '$lib/components/search/searchItemCard.svelte';
     import {setCenter} from '$lib/services/map/map.svelte';
     import type {SearchItem} from '$lib/interfaces/object';
     import {mapState} from '$lib/state/map.svelte.ts';

--- a/src/lib/interfaces/map.ts
+++ b/src/lib/interfaces/map.ts
@@ -1,0 +1,61 @@
+export interface LatLngLiteral {
+    lat: number;
+    lng: number;
+}
+
+export type EventUnsubscribe = () => void;
+
+export interface BoundsPadding {
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
+}
+
+export interface MapBounds {
+    getCenter(): LatLngLiteral;
+    contains(point: LatLngLiteral): boolean;
+    extend(point: LatLngLiteral): void;
+}
+
+export interface MarkerHandleOptions {
+    zIndex?: number;
+    clickable?: boolean;
+}
+
+export interface IMarkerHandle {
+    setPosition(latLng: LatLngLiteral): void;
+    getPosition(): LatLngLiteral;
+    show(): void;
+    hide(): void;
+    remove(): void;
+    getElement(): HTMLElement | null;
+    addClickListener(callback: () => void): EventUnsubscribe;
+}
+
+export interface IMapProvider {
+    getZoom(): number;
+    setZoom(zoom: number): void;
+    getCenter(): LatLngLiteral | undefined;
+    getBounds(): MapBounds | undefined;
+    setCenter(lat: number, lng: number): void;
+    fitBounds(bounds: MapBounds, padding?: BoundsPadding): void;
+    createBounds(): MapBounds;
+    setDraggable(isDraggable: boolean): void;
+
+    onIdle(callback: () => void): EventUnsubscribe;
+    onClick(callback: (latLng: LatLngLiteral) => void): EventUnsubscribe;
+    onDragEnd(callback: () => void): EventUnsubscribe;
+    onCenterChanged(callback: (center: LatLngLiteral, zoom: number) => void): EventUnsubscribe;
+    onPointerMove(callback: (latLng: LatLngLiteral) => void): EventUnsubscribe;
+
+    createMarkerHandle(
+        position: LatLngLiteral,
+        content: HTMLElement,
+        options?: MarkerHandleOptions,
+    ): IMarkerHandle;
+    preloadMarkerLibrary(): Promise<void>;
+
+    closeStreetView(): void;
+    destroy(): void;
+}

--- a/src/lib/interfaces/map.ts
+++ b/src/lib/interfaces/map.ts
@@ -23,7 +23,7 @@ export interface MarkerHandleOptions {
     clickable?: boolean;
 }
 
-export interface IMarkerHandle {
+export interface MarkerHandle {
     setPosition(latLng: LatLngLiteral): void;
     getPosition(): LatLngLiteral;
     show(): void;
@@ -33,7 +33,7 @@ export interface IMarkerHandle {
     addClickListener(callback: () => void): EventUnsubscribe;
 }
 
-export interface IMapProvider {
+export interface MapProvider {
     getZoom(): number;
     setZoom(zoom: number): void;
     getCenter(): LatLngLiteral | undefined;
@@ -53,7 +53,7 @@ export interface IMapProvider {
         position: LatLngLiteral,
         content: HTMLElement,
         options?: MarkerHandleOptions,
-    ): IMarkerHandle;
+    ): MarkerHandle;
     preloadMarkerLibrary(): Promise<void>;
 
     closeStreetView(): void;

--- a/src/lib/services/map/map.svelte.ts
+++ b/src/lib/services/map/map.svelte.ts
@@ -3,13 +3,8 @@ import {mapState} from '$lib/state/map.svelte';
 
 export function setCenter(lat: number, lng: number) {
     if (mapState.isReady) {
+        mapState.provider!.setZoom(15);
         mapState.provider!.setCenter(lat, lng);
-    }
-}
-
-export function setDraggable(isDraggable: boolean) {
-    if (mapState.isReady) {
-        mapState.provider!.setDraggable(isDraggable);
     }
 }
 

--- a/src/lib/services/map/map.svelte.ts
+++ b/src/lib/services/map/map.svelte.ts
@@ -2,39 +2,34 @@ import type {MapPlaceable} from '$lib/interfaces/object';
 import {mapState} from '$lib/state/map.svelte';
 
 export function setCenter(lat: number, lng: number) {
-    if (mapState.map) {
-        mapState.map.setZoom(15);
-        mapState.map.panTo(new google.maps.LatLng(lat, lng));
+    if (mapState.isReady) {
+        mapState.provider.setCenter(lat, lng);
     }
 }
 
 export function setDraggable(isDraggable: boolean) {
-    if (mapState.map) {
-        mapState.map.set('draggable', isDraggable);
+    if (mapState.isReady) {
+        mapState.provider.setDraggable(isDraggable);
     }
 }
 
 export function fitMarkerList(objects: MapPlaceable[], currentCenter?: MapPlaceable) {
-    if (objects.length === 0) {
+    if (objects.length === 0 || !mapState.isReady) {
         return;
     }
 
-    if (mapState.map) {
-        const latlngbounds = new google.maps.LatLngBounds();
-        if (currentCenter) {
-            latlngbounds.extend(
-                new google.maps.LatLng(currentCenter.latitude, currentCenter.longitude),
-            );
-        }
-
-        for (const object of objects) {
-            latlngbounds.extend(new google.maps.LatLng(object.latitude, object.longitude));
-        }
-        mapState.map.fitBounds(
-            latlngbounds,
-            document.body.clientWidth > 640
-                ? {left: 424, top: 24, bottom: 24, right: 24}
-                : {left: 24, top: 132, bottom: 24, right: 24},
-        );
+    const bounds = mapState.provider.createBounds();
+    if (currentCenter) {
+        bounds.extend({lat: currentCenter.latitude, lng: currentCenter.longitude});
     }
+    for (const object of objects) {
+        bounds.extend({lat: object.latitude, lng: object.longitude});
+    }
+
+    mapState.provider.fitBounds(
+        bounds,
+        document.body.clientWidth > 640
+            ? {left: 424, top: 24, bottom: 24, right: 24}
+            : {left: 24, top: 132, bottom: 24, right: 24},
+    );
 }

--- a/src/lib/services/map/map.svelte.ts
+++ b/src/lib/services/map/map.svelte.ts
@@ -3,13 +3,13 @@ import {mapState} from '$lib/state/map.svelte';
 
 export function setCenter(lat: number, lng: number) {
     if (mapState.isReady) {
-        mapState.provider.setCenter(lat, lng);
+        mapState.provider!.setCenter(lat, lng);
     }
 }
 
 export function setDraggable(isDraggable: boolean) {
     if (mapState.isReady) {
-        mapState.provider.setDraggable(isDraggable);
+        mapState.provider!.setDraggable(isDraggable);
     }
 }
 
@@ -18,7 +18,7 @@ export function fitMarkerList(objects: MapPlaceable[], currentCenter?: MapPlacea
         return;
     }
 
-    const bounds = mapState.provider.createBounds();
+    const bounds = mapState.provider!.createBounds();
     if (currentCenter) {
         bounds.extend({lat: currentCenter.latitude, lng: currentCenter.longitude});
     }
@@ -26,7 +26,7 @@ export function fitMarkerList(objects: MapPlaceable[], currentCenter?: MapPlacea
         bounds.extend({lat: object.latitude, lng: object.longitude});
     }
 
-    mapState.provider.fitBounds(
+    mapState.provider!.fitBounds(
         bounds,
         document.body.clientWidth > 640
             ? {left: 424, top: 24, bottom: 24, right: 24}

--- a/src/lib/services/map/marker.ts
+++ b/src/lib/services/map/marker.ts
@@ -1,12 +1,12 @@
-import type {IMarkerHandle, LatLngLiteral} from '$lib/interfaces/map';
+import type {LatLngLiteral, MarkerHandle} from '$lib/interfaces/map';
 import type {MarkerIcon, MarkerOptions, MarkerSource} from '$lib/interfaces/marker';
 
 export class Marker {
-    private handle?: IMarkerHandle;
-    public clickListener?: () => void;
-    public pointerDownListener?: () => void;
-    public pointerMoveListener?: () => void;
-    public pointerUpListener?: () => void;
+    private handle?: MarkerHandle;
+    public unsubClick?: () => void;
+    public unsubPointerDown?: () => void;
+    public unsubPointerMove?: () => void;
+    public unsubPointerUp?: () => void;
     public isDragged = false;
     private isVisited = false;
     private isRemoved = false;
@@ -83,11 +83,11 @@ export class Marker {
         return Boolean(this.handle);
     }
 
-    public getHandle(): IMarkerHandle | undefined {
+    public getHandle(): MarkerHandle | undefined {
         return this.handle;
     }
 
-    public setHandle(handle: IMarkerHandle) {
+    public setHandle(handle: MarkerHandle) {
         this.handle = handle;
     }
 
@@ -117,7 +117,7 @@ export class Marker {
         }
 
         this.pointerDownListener = undefined;
-        this.pointerMoveListener = undefined;
+        this.unsubPointerMove = undefined;
         this.pointerUpListener = undefined;
         this.handle.remove();
         this.handle = undefined;

--- a/src/lib/services/map/marker.ts
+++ b/src/lib/services/map/marker.ts
@@ -116,9 +116,14 @@ export class Marker {
             return;
         }
 
-        this.pointerDownListener = undefined;
+        this.unsubClick?.();
+        this.unsubClick = undefined;
+        this.unsubPointerDown?.();
+        this.unsubPointerDown = undefined;
+        this.unsubPointerMove?.();
         this.unsubPointerMove = undefined;
-        this.pointerUpListener = undefined;
+        this.unsubPointerUp?.();
+        this.unsubPointerUp = undefined;
         this.handle.remove();
         this.handle = undefined;
         onSuccess();

--- a/src/lib/services/map/marker.ts
+++ b/src/lib/services/map/marker.ts
@@ -1,40 +1,37 @@
+import type {IMarkerHandle, LatLngLiteral} from '$lib/interfaces/map';
 import type {MarkerIcon, MarkerOptions, MarkerSource} from '$lib/interfaces/marker';
 
 export class Marker {
-    private marker?: google.maps.marker.AdvancedMarkerElement;
-    public clickListener?: google.maps.MapsEventListener;
+    private handle?: IMarkerHandle;
+    public clickListener?: () => void;
     public pointerDownListener?: () => void;
-    public pointerMoveListener?: google.maps.MapsEventListener;
+    public pointerMoveListener?: () => void;
     public pointerUpListener?: () => void;
     public isDragged = false;
     private isVisited = false;
     private isRemoved = false;
 
     public constructor(
-        private map: google.maps.Map,
-        private position: google.maps.LatLngLiteral,
+        private position: LatLngLiteral,
         private options: MarkerOptions,
     ) {
         this.isVisited = Boolean(options.isVisited);
         this.isRemoved = Boolean(options.isRemoved);
     }
 
-    public getPosition(): google.maps.LatLngLiteral {
+    public getPosition(): LatLngLiteral {
         return this.position;
     }
 
-    public setPosition(position: google.maps.LatLngLiteral) {
-        if (this.marker) {
-            this.marker.position = position;
-        }
+    public setPosition(position: LatLngLiteral) {
+        this.handle?.setPosition(position);
         this.position = position;
     }
 
     public revertPosition() {
-        if (!this.marker) {
-            return;
+        if (this.handle) {
+            this.handle.setPosition(this.position);
         }
-        this.marker.position = this.position;
     }
 
     public getSource(): MarkerSource {
@@ -43,10 +40,6 @@ export class Marker {
 
     public getColor(): string {
         return this.options.color;
-    }
-
-    public getMap(): google.maps.Map {
-        return this.map;
     }
 
     public isDraggable(): boolean {
@@ -87,15 +80,15 @@ export class Marker {
     }
 
     public isCreated(): boolean {
-        return Boolean(this.marker);
+        return Boolean(this.handle);
     }
 
-    public getRaw() {
-        return this.marker;
+    public getHandle(): IMarkerHandle | undefined {
+        return this.handle;
     }
 
-    public setRaw(raw: google.maps.marker.AdvancedMarkerElement) {
-        this.marker = raw;
+    public setHandle(handle: IMarkerHandle) {
+        this.handle = handle;
     }
 
     public create() {
@@ -103,41 +96,31 @@ export class Marker {
     }
 
     public show() {
-        if (!this.marker) {
-            return;
-        }
-
-        if (!this.marker.map) {
-            this.marker.map = this.map;
-        }
+        this.handle?.show();
     }
 
     // this function hides a marker without an animation because we do it when a marker either moves
     // out of viewport bounds (in which case we don't see it, so no need for an animation), or if we
     // hide all markers while moving to deck overlay, in which case an animation causes weird jitter,
-    // so for now it is sipler to just hide without animation.
+    // so for now it is simpler to just hide without animation.
     // There is an edge-case where a marker can be out of viewport only partially, in which case the lack
     // of animation will be visible, but I'm willing to live with that for now
     // TODO: Consider implementing true lazy loading (DOM destruction/recreation) if memory usage becomes an issue.
     // Current approach: DOM caching for better performance and smooth UX
     public hide() {
-        if (!this.marker || !this.marker.map) {
-            return;
-        }
-
-        this.marker.map = null;
+        this.handle?.hide();
     }
 
     public remove(onSuccess: () => void) {
-        if (!this.marker) {
+        if (!this.handle) {
             return;
         }
 
         this.pointerDownListener = undefined;
         this.pointerMoveListener = undefined;
         this.pointerUpListener = undefined;
-        this.marker.map = null;
-        this.marker = undefined;
+        this.handle.remove();
+        this.handle = undefined;
         onSuccess();
     }
 }

--- a/src/lib/services/map/markerManager.ts
+++ b/src/lib/services/map/markerManager.ts
@@ -1,11 +1,11 @@
-import type {IMapProvider, LatLngLiteral} from '$lib/interfaces/map';
+import type {LatLngLiteral, MapProvider} from '$lib/interfaces/map';
 import type {MarkerId, MarkerOptions, MarkerStateUpdate} from '$lib/interfaces/marker';
-import {Marker} from './marker';
-import {MarkerRepository} from './markerRepository';
-import type {MarkerRenderer} from './renderer/markerRenderer';
-import {UpdateScheduler} from './updateScheduler';
-import {ViewportIndex} from './viewportIndex';
-import {VisibilityEngine} from './visibilityEngine';
+import {Marker} from '$lib/services/map/marker';
+import {MarkerRepository} from '$lib/services/map/markerRepository';
+import type {MarkerRenderer} from '$lib/services/map/renderer/markerRenderer';
+import {UpdateScheduler} from '$lib/services/map/updateScheduler';
+import {ViewportIndex} from '$lib/services/map/viewportIndex';
+import {VisibilityEngine} from '$lib/services/map/visibilityEngine';
 
 export type RendererMode = 'dom' | 'deck';
 export type RendererFactory = (mode: RendererMode) => MarkerRenderer;
@@ -28,7 +28,7 @@ export class MarkerManager {
     private isDeck = false;
 
     public constructor(
-        private provider: IMapProvider,
+        private provider: MapProvider,
         private createRenderer: RendererFactory,
         options: Partial<MarkerManagerOptions> = {},
     ) {
@@ -124,12 +124,12 @@ export class MarkerManager {
         this.visibilityEngine.setSuppressed(false);
     }
 
-    public setRendererMode(renderer: RendererMode): RendererMode {
+    public setRendererMode(renderer: RendererMode): void {
         const wasDeck = this.isDeck;
         this.isDeck = renderer === 'deck';
 
         if (wasDeck === this.isDeck) {
-            return renderer;
+            return;
         }
 
         this.disableMarkers();
@@ -142,8 +142,6 @@ export class MarkerManager {
 
         this.enableMarkers();
         this.scheduleViewportUpdate();
-
-        return renderer;
     }
 
     public removeMarker(id: MarkerId) {

--- a/src/lib/services/map/markerManager.ts
+++ b/src/lib/services/map/markerManager.ts
@@ -1,19 +1,21 @@
+import type {IMapProvider, LatLngLiteral} from '$lib/interfaces/map';
 import type {MarkerId, MarkerOptions, MarkerStateUpdate} from '$lib/interfaces/marker';
-import type {Loader} from '@googlemaps/js-api-loader';
 import {Marker} from './marker';
 import {MarkerRepository} from './markerRepository';
 import {DomMarkerRenderer} from './renderer/domMarkerRenderer';
-import {HybridMarkerRenderer} from './renderer/hybridMarkerRenderer';
 import type {MarkerRenderer} from './renderer/markerRenderer';
 import {UpdateScheduler} from './updateScheduler';
 import {ViewportIndex} from './viewportIndex';
 import {VisibilityEngine} from './visibilityEngine';
 
+export type RendererMode = 'dom' | 'deck';
+export type RendererFactory = (mode: RendererMode) => MarkerRenderer;
+
 export interface MarkerManagerOptions {
-    chunkSize: number; // Number of markers to process per animation frame
-    maxVisibleMarkers: number; // Maximum markers to display on screen at once
-    maxZoom: number; // Maximum zoom level to display markers
-    renderer?: 'dom' | 'deck';
+    chunkSize: number;
+    maxVisibleMarkers: number;
+    maxZoom: number;
+    renderer?: RendererMode;
 }
 
 export class MarkerManager {
@@ -27,7 +29,8 @@ export class MarkerManager {
     private isDeck = false;
 
     public constructor(
-        private map: google.maps.Map,
+        private provider: IMapProvider,
+        private createRenderer: RendererFactory,
         options: Partial<MarkerManagerOptions> = {},
     ) {
         this.options = {
@@ -39,7 +42,7 @@ export class MarkerManager {
         };
 
         this.isDeck = this.options.renderer === 'deck';
-        this.renderer = this.isDeck ? new HybridMarkerRenderer(this.map) : new DomMarkerRenderer();
+        this.renderer = createRenderer(this.isDeck ? 'deck' : 'dom');
         this.visibilityEngine = new VisibilityEngine(
             this.repo,
             {chunkSize: this.options.chunkSize},
@@ -47,9 +50,9 @@ export class MarkerManager {
         );
     }
 
-    public async initialize(mapLoader: Loader) {
+    public async initialize() {
         try {
-            await mapLoader.importLibrary('marker');
+            await this.provider.preloadMarkerLibrary();
         } catch (error: unknown) {
             console.error('Failed to pre-load marker library:', error);
         }
@@ -57,14 +60,14 @@ export class MarkerManager {
 
     public addMarker(
         id: MarkerId,
-        position: google.maps.LatLngLiteral,
+        position: LatLngLiteral,
         options: MarkerOptions,
     ): Marker | null {
         const isLazy = options.source === 'list';
 
         const upsert = this.repo.upsertWithPolicy(
             id,
-            () => new Marker(this.map, position, options),
+            () => new Marker(position, options),
             options.source,
         );
 
@@ -121,24 +124,26 @@ export class MarkerManager {
         this.visibilityEngine.setSuppressed(false);
     }
 
-    public setRendererMode(renderer: 'dom' | 'deck') {
+    public setRendererMode(renderer: RendererMode): RendererMode {
         const wasDeck = this.isDeck;
         this.isDeck = renderer === 'deck';
 
         if (wasDeck === this.isDeck) {
-            return;
+            return renderer;
         }
 
         this.disableMarkers();
 
         this.renderer.destroy();
-        this.renderer = this.isDeck ? new HybridMarkerRenderer(this.map) : new DomMarkerRenderer();
+        this.renderer = this.createRenderer(this.isDeck ? 'deck' : 'dom');
         this.visibilityEngine.setRenderer(this.renderer);
 
         this.renderer.syncAll(this.repo.values());
 
         this.enableMarkers();
         this.scheduleViewportUpdate();
+
+        return renderer;
     }
 
     public removeMarker(id: MarkerId) {
@@ -167,7 +172,7 @@ export class MarkerManager {
     }
 
     private updateMarkersInViewport() {
-        const bounds = this.map.getBounds();
+        const bounds = this.provider.getBounds();
         if (!bounds || this.scheduler.isSuppressed) {
             this.scheduler.complete();
             return;
@@ -175,10 +180,9 @@ export class MarkerManager {
 
         const candidates = this.viewportIndex.collect(bounds, this.repo);
         const center = bounds.getCenter();
-        const centerPosition = {lat: center.lat(), lng: center.lng()};
         const visibleIds = this.viewportIndex.selectVisible(
             candidates,
-            centerPosition,
+            center,
             this.options.maxVisibleMarkers,
         );
 

--- a/src/lib/services/map/markerManager.ts
+++ b/src/lib/services/map/markerManager.ts
@@ -2,7 +2,6 @@ import type {IMapProvider, LatLngLiteral} from '$lib/interfaces/map';
 import type {MarkerId, MarkerOptions, MarkerStateUpdate} from '$lib/interfaces/marker';
 import {Marker} from './marker';
 import {MarkerRepository} from './markerRepository';
-import {DomMarkerRenderer} from './renderer/domMarkerRenderer';
 import type {MarkerRenderer} from './renderer/markerRenderer';
 import {UpdateScheduler} from './updateScheduler';
 import {ViewportIndex} from './viewportIndex';

--- a/src/lib/services/map/markerManager.ts
+++ b/src/lib/services/map/markerManager.ts
@@ -49,11 +49,16 @@ export class MarkerManager {
         );
     }
 
+    public get isDeckRenderer(): boolean {
+        return this.isDeck;
+    }
+
     public async initialize() {
         try {
             await this.provider.preloadMarkerLibrary();
         } catch (error: unknown) {
             console.error('Failed to pre-load marker library:', error);
+            throw error;
         }
     }
 

--- a/src/lib/services/map/markerManager.ts
+++ b/src/lib/services/map/markerManager.ts
@@ -57,11 +57,7 @@ export class MarkerManager {
         }
     }
 
-    public addMarker(
-        id: MarkerId,
-        position: LatLngLiteral,
-        options: MarkerOptions,
-    ): Marker | null {
+    public addMarker(id: MarkerId, position: LatLngLiteral, options: MarkerOptions): Marker | null {
         const isLazy = options.source === 'list';
 
         const upsert = this.repo.upsertWithPolicy(

--- a/src/lib/services/map/providers/google/bounds.ts
+++ b/src/lib/services/map/providers/google/bounds.ts
@@ -1,0 +1,22 @@
+import type {LatLngLiteral, MapBounds} from '$lib/interfaces/map';
+
+export class GoogleMapBounds implements MapBounds {
+    constructor(private bounds: google.maps.LatLngBounds) {}
+
+    getCenter(): LatLngLiteral {
+        const center = this.bounds.getCenter();
+        return {lat: center.lat(), lng: center.lng()};
+    }
+
+    contains(point: LatLngLiteral): boolean {
+        return this.bounds.contains(point);
+    }
+
+    extend(point: LatLngLiteral): void {
+        this.bounds.extend(point);
+    }
+
+    get raw(): google.maps.LatLngBounds {
+        return this.bounds;
+    }
+}

--- a/src/lib/services/map/providers/google/deckOverlayRenderer.ts
+++ b/src/lib/services/map/providers/google/deckOverlayRenderer.ts
@@ -16,9 +16,9 @@ export class DeckOverlayRenderer implements MarkerRenderer {
     private allMarkers = new Set<Marker>();
     private scheduled = false;
 
-    public constructor(private map: google.maps.Map) {
+    public constructor(map: google.maps.Map) {
         this.overlay = new GoogleMapsOverlay({layers: []});
-        this.overlay.setMap(this.map);
+        this.overlay.setMap(map);
     }
 
     public ensureCreated(marker: Marker): void {
@@ -45,9 +45,7 @@ export class DeckOverlayRenderer implements MarkerRenderer {
     public remove(marker: Marker, onRemoved?: () => void): void {
         this.allMarkers.delete(marker);
         this.scheduleRender();
-        if (onRemoved) {
-            onRemoved();
-        }
+        onRemoved?.();
     }
 
     public applyState(_marker: Marker): void {

--- a/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
+++ b/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
@@ -1,14 +1,21 @@
 import type {Marker} from '$lib/services/map/marker';
-import {DeckOverlayRenderer} from '$lib/services/map/renderer/deckOverlayRenderer';
 import {DomMarkerRenderer} from '$lib/services/map/renderer/domMarkerRenderer';
 import type {MarkerRenderer} from '$lib/services/map/renderer/markerRenderer';
+import type {IMapProvider} from '$lib/interfaces/map';
+import {DeckOverlayRenderer} from './deckOverlayRenderer';
+import type {GoogleMapsProvider} from './provider';
 
 export class HybridMarkerRenderer implements MarkerRenderer {
-    private dom = new DomMarkerRenderer();
+    private dom: DomMarkerRenderer;
     private deck: DeckOverlayRenderer;
 
-    public constructor(map: google.maps.Map) {
-        this.deck = new DeckOverlayRenderer(map);
+    public constructor(provider: IMapProvider) {
+        this.dom = new DomMarkerRenderer(provider);
+        const googleMap = (provider as GoogleMapsProvider).getGoogleMap();
+        if (!googleMap) {
+            throw new Error('GoogleMapsProvider map not initialized');
+        }
+        this.deck = new DeckOverlayRenderer(googleMap);
     }
 
     public ensureCreated(marker: Marker): void {

--- a/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
+++ b/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
@@ -1,7 +1,7 @@
+import type {IMapProvider} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
 import {DomMarkerRenderer} from '$lib/services/map/renderer/domMarkerRenderer';
 import type {MarkerRenderer} from '$lib/services/map/renderer/markerRenderer';
-import type {IMapProvider} from '$lib/interfaces/map';
 import {DeckOverlayRenderer} from './deckOverlayRenderer';
 import type {GoogleMapsProvider} from './provider';
 

--- a/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
+++ b/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
@@ -1,15 +1,15 @@
-import type {IMapProvider} from '$lib/interfaces/map';
+import type {MapProvider} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
+import {DeckOverlayRenderer} from '$lib/services/map/providers/google/deckOverlayRenderer';
+import type {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
 import {DomMarkerRenderer} from '$lib/services/map/renderer/domMarkerRenderer';
 import type {MarkerRenderer} from '$lib/services/map/renderer/markerRenderer';
-import {DeckOverlayRenderer} from './deckOverlayRenderer';
-import type {GoogleMapsProvider} from './provider';
 
 export class HybridMarkerRenderer implements MarkerRenderer {
     private dom: DomMarkerRenderer;
     private deck: DeckOverlayRenderer;
 
-    public constructor(provider: IMapProvider) {
+    public constructor(provider: MapProvider) {
         this.dom = new DomMarkerRenderer(provider);
         const googleMap = (provider as GoogleMapsProvider).getGoogleMap();
         if (!googleMap) {

--- a/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
+++ b/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
@@ -11,6 +11,9 @@ export class HybridMarkerRenderer implements MarkerRenderer {
 
     public constructor(provider: MapProvider) {
         this.dom = new DomMarkerRenderer(provider);
+        if (!('getGoogleMap' in provider) || typeof provider.getGoogleMap !== 'function') {
+            throw new Error('HybridMarkerRenderer requires a GoogleMapsProvider');
+        }
         const googleMap = (provider as GoogleMapsProvider).getGoogleMap();
         if (!googleMap) {
             throw new Error('GoogleMapsProvider map not initialized');

--- a/src/lib/services/map/providers/google/markerHandle.ts
+++ b/src/lib/services/map/providers/google/markerHandle.ts
@@ -1,0 +1,57 @@
+import type {EventUnsubscribe, IMarkerHandle, LatLngLiteral, MarkerHandleOptions} from '$lib/interfaces/map';
+
+export class GoogleMarkerHandle implements IMarkerHandle {
+    private marker: google.maps.marker.AdvancedMarkerElement;
+
+    constructor(
+        private map: google.maps.Map,
+        position: LatLngLiteral,
+        content: HTMLElement,
+        options: MarkerHandleOptions = {},
+    ) {
+        this.marker = new google.maps.marker.AdvancedMarkerElement({
+            position,
+            content,
+            collisionBehavior: google.maps.CollisionBehavior.REQUIRED,
+            gmpClickable: options.clickable !== false,
+            zIndex: options.zIndex ?? 0,
+        });
+    }
+
+    setPosition(latLng: LatLngLiteral): void {
+        this.marker.position = latLng;
+    }
+
+    getPosition(): LatLngLiteral {
+        const pos = this.marker.position;
+        if (!pos) return {lat: 0, lng: 0};
+        if (typeof (pos as google.maps.LatLng).lat === 'function') {
+            const latlng = pos as google.maps.LatLng;
+            return {lat: latlng.lat(), lng: latlng.lng()};
+        }
+        return {lat: (pos as LatLngLiteral).lat, lng: (pos as LatLngLiteral).lng};
+    }
+
+    show(): void {
+        if (!this.marker.map) {
+            this.marker.map = this.map;
+        }
+    }
+
+    hide(): void {
+        this.marker.map = null;
+    }
+
+    remove(): void {
+        this.marker.map = null;
+    }
+
+    getElement(): HTMLElement | null {
+        return this.marker.content instanceof HTMLElement ? this.marker.content : null;
+    }
+
+    addClickListener(callback: () => void): EventUnsubscribe {
+        const listener = this.marker.addListener('gmp-click', callback);
+        return () => google.maps.event.removeListener(listener);
+    }
+}

--- a/src/lib/services/map/providers/google/markerHandle.ts
+++ b/src/lib/services/map/providers/google/markerHandle.ts
@@ -1,11 +1,11 @@
 import type {
     EventUnsubscribe,
-    IMarkerHandle,
     LatLngLiteral,
+    MarkerHandle,
     MarkerHandleOptions,
 } from '$lib/interfaces/map';
 
-export class GoogleMarkerHandle implements IMarkerHandle {
+export class GoogleMarkerHandle implements MarkerHandle {
     private marker: google.maps.marker.AdvancedMarkerElement;
 
     constructor(

--- a/src/lib/services/map/providers/google/markerHandle.ts
+++ b/src/lib/services/map/providers/google/markerHandle.ts
@@ -1,4 +1,9 @@
-import type {EventUnsubscribe, IMarkerHandle, LatLngLiteral, MarkerHandleOptions} from '$lib/interfaces/map';
+import type {
+    EventUnsubscribe,
+    IMarkerHandle,
+    LatLngLiteral,
+    MarkerHandleOptions,
+} from '$lib/interfaces/map';
 
 export class GoogleMarkerHandle implements IMarkerHandle {
     private marker: google.maps.marker.AdvancedMarkerElement;
@@ -24,7 +29,9 @@ export class GoogleMarkerHandle implements IMarkerHandle {
 
     getPosition(): LatLngLiteral {
         const pos = this.marker.position;
-        if (!pos) return {lat: 0, lng: 0};
+        if (!pos) {
+            return {lat: 0, lng: 0};
+        }
         if (typeof (pos as google.maps.LatLng).lat === 'function') {
             const latlng = pos as google.maps.LatLng;
             return {lat: latlng.lat(), lng: latlng.lng()};
@@ -43,7 +50,7 @@ export class GoogleMarkerHandle implements IMarkerHandle {
     }
 
     remove(): void {
-        this.marker.map = null;
+        this.hide();
     }
 
     getElement(): HTMLElement | null {

--- a/src/lib/services/map/providers/google/provider.ts
+++ b/src/lib/services/map/providers/google/provider.ts
@@ -74,7 +74,6 @@ export class GoogleMapsProvider implements MapProvider {
     }
 
     setCenter(lat: number, lng: number): void {
-        this.map?.setZoom(15);
         this.map?.panTo(new google.maps.LatLng(lat, lng));
     }
 

--- a/src/lib/services/map/providers/google/provider.ts
+++ b/src/lib/services/map/providers/google/provider.ts
@@ -3,26 +3,18 @@ import type {Location} from '$lib/interfaces/location';
 import type {
     BoundsPadding,
     EventUnsubscribe,
-    IMapProvider,
-    IMarkerHandle,
     LatLngLiteral,
     MapBounds,
+    MapProvider,
+    MarkerHandle,
     MarkerHandleOptions,
 } from '$lib/interfaces/map';
-import {mapState} from '$lib/state/map.svelte';
+import {GoogleMapBounds} from '$lib/services/map/providers/google/bounds';
+import {GoogleMarkerHandle} from '$lib/services/map/providers/google/markerHandle';
 import {themeState} from '$lib/state/theme.svelte';
 import {Loader} from '@googlemaps/js-api-loader';
-import {GoogleMapBounds} from './bounds';
-import {GoogleMarkerHandle} from './markerHandle';
 
-export function getGoogleProvider(): GoogleMapsProvider {
-    if (!(mapState.provider instanceof GoogleMapsProvider)) {
-        throw new Error('Expected GoogleMapsProvider');
-    }
-    return mapState.provider;
-}
-
-export class GoogleMapsProvider implements IMapProvider {
+export class GoogleMapsProvider implements MapProvider {
     readonly loader: Loader;
     private map?: google.maps.Map;
 
@@ -166,7 +158,7 @@ export class GoogleMapsProvider implements IMapProvider {
         position: LatLngLiteral,
         content: HTMLElement,
         options: MarkerHandleOptions = {},
-    ): IMarkerHandle {
+    ): MarkerHandle {
         if (!this.map) {
             throw new Error('Map not initialized');
         }

--- a/src/lib/services/map/providers/google/provider.ts
+++ b/src/lib/services/map/providers/google/provider.ts
@@ -1,0 +1,178 @@
+import type {
+    BoundsPadding,
+    EventUnsubscribe,
+    IMapProvider,
+    IMarkerHandle,
+    LatLngLiteral,
+    MapBounds,
+    MarkerHandleOptions,
+} from '$lib/interfaces/map';
+import type {Location} from '$lib/interfaces/location';
+import config from '$lib/config';
+import {themeState} from '$lib/state/theme.svelte';
+import {Loader} from '@googlemaps/js-api-loader';
+import {GoogleMapBounds} from './bounds';
+import {GoogleMarkerHandle} from './markerHandle';
+
+export class GoogleMapsProvider implements IMapProvider {
+    readonly loader: Loader;
+    private map?: google.maps.Map;
+
+    constructor() {
+        this.loader = new Loader({
+            apiKey: config.googleMapsApiKey,
+            version: 'weekly',
+            libraries: ['places', 'marker'],
+        });
+    }
+
+    async initialize(container: HTMLElement, center: Location): Promise<void> {
+        const [{Map}, {ColorScheme}] = await Promise.all([
+            this.loader.importLibrary('maps'),
+            this.loader.importLibrary('core'),
+        ]);
+
+        this.map = new Map(container, {
+            zoom: center.zoom ?? 15,
+            center,
+            mapId: config.googleMapsId,
+            controlSize: 40,
+            mapTypeControl: false,
+            cameraControl: false,
+            fullscreenControl: false,
+            zoomControl: false,
+            clickableIcons: false,
+            colorScheme: this.resolveColorScheme(ColorScheme),
+        });
+    }
+
+    private resolveColorScheme(
+        ColorScheme: typeof google.maps.ColorScheme,
+    ): google.maps.ColorScheme {
+        if (themeState.preference === 'system') {
+            return ColorScheme.FOLLOW_SYSTEM;
+        }
+        return themeState.resolved === 'dark' ? ColorScheme.DARK : ColorScheme.LIGHT;
+    }
+
+    getZoom(): number {
+        return this.map?.getZoom() ?? 15;
+    }
+
+    setZoom(zoom: number): void {
+        this.map?.setZoom(zoom);
+    }
+
+    getCenter(): LatLngLiteral | undefined {
+        const center = this.map?.getCenter();
+        return center ? {lat: center.lat(), lng: center.lng()} : undefined;
+    }
+
+    getBounds(): MapBounds | undefined {
+        const bounds = this.map?.getBounds();
+        return bounds ? new GoogleMapBounds(bounds) : undefined;
+    }
+
+    setCenter(lat: number, lng: number): void {
+        this.map?.setZoom(15);
+        this.map?.panTo(new google.maps.LatLng(lat, lng));
+    }
+
+    fitBounds(bounds: MapBounds, padding?: BoundsPadding): void {
+        if (!(bounds instanceof GoogleMapBounds) || !this.map) {
+            return;
+        }
+        this.map.fitBounds(bounds.raw, padding);
+    }
+
+    createBounds(): MapBounds {
+        return new GoogleMapBounds(new google.maps.LatLngBounds());
+    }
+
+    setDraggable(isDraggable: boolean): void {
+        this.map?.set('draggable', isDraggable);
+    }
+
+    onIdle(callback: () => void): EventUnsubscribe {
+        if (!this.map) return () => {};
+        const listener = google.maps.event.addListener(this.map, 'idle', callback);
+        return () => google.maps.event.removeListener(listener);
+    }
+
+    onClick(callback: (latLng: LatLngLiteral) => void): EventUnsubscribe {
+        if (!this.map) return () => {};
+        const listener = google.maps.event.addListener(
+            this.map,
+            'click',
+            (event: google.maps.MapMouseEvent) => {
+                if (event.latLng) {
+                    callback({lat: event.latLng.lat(), lng: event.latLng.lng()});
+                }
+            },
+        );
+        return () => google.maps.event.removeListener(listener);
+    }
+
+    onDragEnd(callback: () => void): EventUnsubscribe {
+        if (!this.map) return () => {};
+        const listener = google.maps.event.addListener(this.map, 'dragend', callback);
+        return () => google.maps.event.removeListener(listener);
+    }
+
+    onCenterChanged(
+        callback: (center: LatLngLiteral, zoom: number) => void,
+    ): EventUnsubscribe {
+        if (!this.map) return () => {};
+        const listener = google.maps.event.addListener(this.map, 'center_changed', () => {
+            const center = this.map!.getCenter();
+            if (center) {
+                callback({lat: center.lat(), lng: center.lng()}, this.map!.getZoom() ?? 15);
+            }
+        });
+        return () => google.maps.event.removeListener(listener);
+    }
+
+    onPointerMove(callback: (latLng: LatLngLiteral) => void): EventUnsubscribe {
+        if (!this.map) return () => {};
+        const listener = google.maps.event.addListener(
+            this.map,
+            'mousemove',
+            (event: google.maps.MapMouseEvent) => {
+                if (event.latLng) {
+                    callback({lat: event.latLng.lat(), lng: event.latLng.lng()});
+                }
+            },
+        );
+        return () => google.maps.event.removeListener(listener);
+    }
+
+    createMarkerHandle(
+        position: LatLngLiteral,
+        content: HTMLElement,
+        options: MarkerHandleOptions = {},
+    ): IMarkerHandle {
+        if (!this.map) {
+            throw new Error('Map not initialized');
+        }
+        return new GoogleMarkerHandle(this.map, position, content, options);
+    }
+
+    async preloadMarkerLibrary(): Promise<void> {
+        await this.loader.importLibrary('marker');
+    }
+
+    closeStreetView(): void {
+        this.map?.getStreetView().setVisible(false);
+    }
+
+    destroy(): void {
+        if (this.map) {
+            google.maps.event.clearInstanceListeners(this.map);
+        }
+        this.map = undefined;
+    }
+
+    getGoogleMap(): google.maps.Map | undefined {
+        return this.map;
+    }
+}

--- a/src/lib/services/map/providers/google/provider.ts
+++ b/src/lib/services/map/providers/google/provider.ts
@@ -22,7 +22,7 @@ export class GoogleMapsProvider implements IMapProvider {
         this.loader = new Loader({
             apiKey: config.googleMapsApiKey,
             version: 'weekly',
-            libraries: ['places', 'marker'],
+            libraries: ['places'],
         });
     }
 

--- a/src/lib/services/map/providers/google/provider.ts
+++ b/src/lib/services/map/providers/google/provider.ts
@@ -1,3 +1,5 @@
+import config from '$lib/config';
+import type {Location} from '$lib/interfaces/location';
 import type {
     BoundsPadding,
     EventUnsubscribe,
@@ -7,12 +9,18 @@ import type {
     MapBounds,
     MarkerHandleOptions,
 } from '$lib/interfaces/map';
-import type {Location} from '$lib/interfaces/location';
-import config from '$lib/config';
+import {mapState} from '$lib/state/map.svelte';
 import {themeState} from '$lib/state/theme.svelte';
 import {Loader} from '@googlemaps/js-api-loader';
 import {GoogleMapBounds} from './bounds';
 import {GoogleMarkerHandle} from './markerHandle';
+
+export function getGoogleProvider(): GoogleMapsProvider {
+    if (!(mapState.provider instanceof GoogleMapsProvider)) {
+        throw new Error('Expected GoogleMapsProvider');
+    }
+    return mapState.provider;
+}
 
 export class GoogleMapsProvider implements IMapProvider {
     readonly loader: Loader;
@@ -94,13 +102,17 @@ export class GoogleMapsProvider implements IMapProvider {
     }
 
     onIdle(callback: () => void): EventUnsubscribe {
-        if (!this.map) return () => {};
+        if (!this.map) {
+            return () => {};
+        }
         const listener = google.maps.event.addListener(this.map, 'idle', callback);
         return () => google.maps.event.removeListener(listener);
     }
 
     onClick(callback: (latLng: LatLngLiteral) => void): EventUnsubscribe {
-        if (!this.map) return () => {};
+        if (!this.map) {
+            return () => {};
+        }
         const listener = google.maps.event.addListener(
             this.map,
             'click',
@@ -114,15 +126,17 @@ export class GoogleMapsProvider implements IMapProvider {
     }
 
     onDragEnd(callback: () => void): EventUnsubscribe {
-        if (!this.map) return () => {};
+        if (!this.map) {
+            return () => {};
+        }
         const listener = google.maps.event.addListener(this.map, 'dragend', callback);
         return () => google.maps.event.removeListener(listener);
     }
 
-    onCenterChanged(
-        callback: (center: LatLngLiteral, zoom: number) => void,
-    ): EventUnsubscribe {
-        if (!this.map) return () => {};
+    onCenterChanged(callback: (center: LatLngLiteral, zoom: number) => void): EventUnsubscribe {
+        if (!this.map) {
+            return () => {};
+        }
         const listener = google.maps.event.addListener(this.map, 'center_changed', () => {
             const center = this.map!.getCenter();
             if (center) {
@@ -133,7 +147,9 @@ export class GoogleMapsProvider implements IMapProvider {
     }
 
     onPointerMove(callback: (latLng: LatLngLiteral) => void): EventUnsubscribe {
-        if (!this.map) return () => {};
+        if (!this.map) {
+            return () => {};
+        }
         const listener = google.maps.event.addListener(
             this.map,
             'mousemove',

--- a/src/lib/services/map/renderer/dom/dragController.ts
+++ b/src/lib/services/map/renderer/dom/dragController.ts
@@ -1,14 +1,16 @@
+import type {IMapProvider, LatLngLiteral} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
-import {mapState} from '$lib/state/map.svelte';
 import {removeDragTimeout, setDragTimeout} from '$lib/state/marker.svelte';
 import {setDraggable} from '../../map.svelte';
 
 export class DragController {
     private skipClick = false;
 
+    public constructor(private provider: IMapProvider) {}
+
     public attach(marker: Marker): void {
-        const raw = marker.getRaw();
-        if (!raw) {
+        const handle = marker.getHandle();
+        if (!handle) {
             return;
         }
 
@@ -17,28 +19,20 @@ export class DragController {
     }
 
     public detach(marker: Marker): void {
-        const raw = marker.getRaw();
-        if (!raw) {
-            return;
-        }
-
-        google.maps.event.clearInstanceListeners(raw);
+        marker.clickListener?.();
+        marker.clickListener = undefined;
         this.removeDomPointerListeners(marker);
         this.removeMapMoveListener(marker);
     }
 
     private attachClick(marker: Marker): void {
-        const raw = marker.getRaw();
-        if (!raw) {
+        const handle = marker.getHandle();
+        if (!handle) {
             return;
         }
 
-        if (marker.clickListener) {
-            google.maps.event.removeListener(marker.clickListener);
-            marker.clickListener = undefined;
-        }
-
-        marker.clickListener = raw.addListener('gmp-click', this.handleClick(marker));
+        marker.clickListener?.();
+        marker.clickListener = handle.addClickListener(this.handleClick(marker));
     }
 
     private handleClick(marker: Marker) {
@@ -47,8 +41,7 @@ export class DragController {
                 this.skipClick = false;
                 return;
             }
-            const onClick = marker.getOnClick();
-            onClick?.();
+            marker.getOnClick()?.();
         };
     }
 
@@ -61,17 +54,17 @@ export class DragController {
     }
 
     private attachPointerDown(marker: Marker): void {
-        const markerContent = marker.getRaw()?.content;
-        if (!markerContent || !(markerContent instanceof HTMLElement)) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             return;
         }
 
         if (marker.pointerDownListener) {
-            markerContent.removeEventListener('pointerdown', marker.pointerDownListener);
+            element.removeEventListener('pointerdown', marker.pointerDownListener);
         }
 
         const onPointerDown = this.handlePointerDown(marker);
-        markerContent.addEventListener('pointerdown', onPointerDown);
+        element.addEventListener('pointerdown', onPointerDown);
         marker.pointerDownListener = onPointerDown;
     }
 
@@ -82,51 +75,36 @@ export class DragController {
     }
 
     private startDrag(marker: Marker) {
-        const markerContent = marker.getRaw()?.content;
-        if (!markerContent || !(markerContent instanceof HTMLElement)) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             return;
         }
-        marker.pointerMoveListener = this.createMapMoveListener(marker);
-        this.skipClick = true;
-        setDraggable(false);
-        const start = marker.getOnDragStart();
-        start?.();
-        markerContent.classList.add('marker-dragging');
-    }
-
-    private createMapMoveListener(marker: Marker): google.maps.MapsEventListener {
-        if (!mapState.map) {
-            throw new Error('Map is not initialized');
-        }
-
-        return google.maps.event.addListener(
-            mapState.map,
-            'mousemove',
-            (event: google.maps.MapMouseEvent) => {
-                if (!event.latLng) {
-                    return;
-                }
-
+        marker.pointerMoveListener = this.provider.onPointerMove(
+            (latLng: LatLngLiteral) => {
                 marker.isDragged = true;
-                marker.setPosition({lat: event.latLng.lat(), lng: event.latLng.lng()});
+                marker.setPosition(latLng);
             },
         );
+        this.skipClick = true;
+        setDraggable(false);
+        marker.getOnDragStart()?.();
+        element.classList.add('marker-dragging');
     }
 
     private attachPointerUp(marker: Marker): void {
-        const markerContent = marker.getRaw()?.content;
-        if (!markerContent || !(markerContent instanceof HTMLElement)) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             return;
         }
 
         if (marker.pointerUpListener) {
-            markerContent.removeEventListener('pointerup', marker.pointerUpListener);
-            markerContent.removeEventListener('pointercancel', marker.pointerUpListener);
+            element.removeEventListener('pointerup', marker.pointerUpListener);
+            element.removeEventListener('pointercancel', marker.pointerUpListener);
         }
 
         const onPointerUp = this.handlePointerUp(marker);
-        markerContent.addEventListener('pointerup', onPointerUp);
-        markerContent.addEventListener('pointercancel', onPointerUp);
+        element.addEventListener('pointerup', onPointerUp);
+        element.addEventListener('pointercancel', onPointerUp);
         marker.pointerUpListener = onPointerUp;
     }
 
@@ -137,37 +115,33 @@ export class DragController {
             setDraggable(true);
             if (marker.isDragged) {
                 marker.isDragged = false;
-                const end = marker.getOnDragEnd();
-                end?.();
+                marker.getOnDragEnd()?.();
             }
-            const markerContent = marker.getRaw()?.content;
-            if (markerContent && markerContent instanceof HTMLElement) {
-                markerContent.classList.remove('marker-dragging');
-            }
+            marker.getHandle()?.getElement()?.classList.remove('marker-dragging');
         };
     }
 
     private removeMapMoveListener(marker: Marker) {
         if (marker.pointerMoveListener) {
-            google.maps.event.removeListener(marker.pointerMoveListener);
+            marker.pointerMoveListener();
             marker.pointerMoveListener = undefined;
         }
     }
 
     private removeDomPointerListeners(marker: Marker) {
-        const markerContent = marker.getRaw()?.content;
-        if (!markerContent || !(markerContent instanceof HTMLElement)) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             return;
         }
 
         if (marker.pointerDownListener) {
-            markerContent.removeEventListener('pointerdown', marker.pointerDownListener);
+            element.removeEventListener('pointerdown', marker.pointerDownListener);
             marker.pointerDownListener = undefined;
         }
 
         if (marker.pointerUpListener) {
-            markerContent.removeEventListener('pointerup', marker.pointerUpListener);
-            markerContent.removeEventListener('pointercancel', marker.pointerUpListener);
+            element.removeEventListener('pointerup', marker.pointerUpListener);
+            element.removeEventListener('pointercancel', marker.pointerUpListener);
             marker.pointerUpListener = undefined;
         }
     }

--- a/src/lib/services/map/renderer/dom/dragController.ts
+++ b/src/lib/services/map/renderer/dom/dragController.ts
@@ -1,12 +1,12 @@
-import type {IMapProvider, LatLngLiteral} from '$lib/interfaces/map';
+import type {LatLngLiteral, MapProvider} from '$lib/interfaces/map';
+import {setDraggable} from '$lib/services/map/map.svelte';
 import type {Marker} from '$lib/services/map/marker';
 import {removeDragTimeout, setDragTimeout} from '$lib/state/marker.svelte';
-import {setDraggable} from '../../map.svelte';
 
 export class DragController {
     private skipClick = false;
 
-    public constructor(private provider: IMapProvider) {}
+    public constructor(private provider: MapProvider) {}
 
     public attach(marker: Marker): void {
         const handle = marker.getHandle();
@@ -19,8 +19,8 @@ export class DragController {
     }
 
     public detach(marker: Marker): void {
-        marker.clickListener?.();
-        marker.clickListener = undefined;
+        marker.unsubClick?.();
+        marker.unsubClick = undefined;
         this.removeDomPointerListeners(marker);
         this.removeMapMoveListener(marker);
     }
@@ -31,8 +31,8 @@ export class DragController {
             return;
         }
 
-        marker.clickListener?.();
-        marker.clickListener = handle.addClickListener(this.handleClick(marker));
+        marker.unsubClick?.();
+        marker.unsubClick = handle.addClickListener(this.handleClick(marker));
     }
 
     private handleClick(marker: Marker) {
@@ -59,13 +59,10 @@ export class DragController {
             return;
         }
 
-        if (marker.pointerDownListener) {
-            element.removeEventListener('pointerdown', marker.pointerDownListener);
-        }
-
-        const onPointerDown = this.handlePointerDown(marker);
-        element.addEventListener('pointerdown', onPointerDown);
-        marker.pointerDownListener = onPointerDown;
+        marker.unsubPointerDown?.();
+        const handler = this.handlePointerDown(marker);
+        element.addEventListener('pointerdown', handler);
+        marker.unsubPointerDown = () => element.removeEventListener('pointerdown', handler);
     }
 
     private handlePointerDown(marker: Marker) {
@@ -79,7 +76,7 @@ export class DragController {
         if (!element) {
             return;
         }
-        marker.pointerMoveListener = this.provider.onPointerMove((latLng: LatLngLiteral) => {
+        marker.unsubPointerMove = this.provider.onPointerMove((latLng: LatLngLiteral) => {
             marker.isDragged = true;
             marker.setPosition(latLng);
         });
@@ -95,15 +92,14 @@ export class DragController {
             return;
         }
 
-        if (marker.pointerUpListener) {
-            element.removeEventListener('pointerup', marker.pointerUpListener);
-            element.removeEventListener('pointercancel', marker.pointerUpListener);
-        }
-
-        const onPointerUp = this.handlePointerUp(marker);
-        element.addEventListener('pointerup', onPointerUp);
-        element.addEventListener('pointercancel', onPointerUp);
-        marker.pointerUpListener = onPointerUp;
+        marker.unsubPointerUp?.();
+        const handler = this.handlePointerUp(marker);
+        element.addEventListener('pointerup', handler);
+        element.addEventListener('pointercancel', handler);
+        marker.unsubPointerUp = () => {
+            element.removeEventListener('pointerup', handler);
+            element.removeEventListener('pointercancel', handler);
+        };
     }
 
     private handlePointerUp(marker: Marker) {
@@ -120,27 +116,16 @@ export class DragController {
     }
 
     private removeMapMoveListener(marker: Marker) {
-        if (marker.pointerMoveListener) {
-            marker.pointerMoveListener();
-            marker.pointerMoveListener = undefined;
+        if (marker.unsubPointerMove) {
+            marker.unsubPointerMove();
+            marker.unsubPointerMove = undefined;
         }
     }
 
     private removeDomPointerListeners(marker: Marker) {
-        const element = marker.getHandle()?.getElement();
-        if (!element) {
-            return;
-        }
-
-        if (marker.pointerDownListener) {
-            element.removeEventListener('pointerdown', marker.pointerDownListener);
-            marker.pointerDownListener = undefined;
-        }
-
-        if (marker.pointerUpListener) {
-            element.removeEventListener('pointerup', marker.pointerUpListener);
-            element.removeEventListener('pointercancel', marker.pointerUpListener);
-            marker.pointerUpListener = undefined;
-        }
+        marker.unsubPointerDown?.();
+        marker.unsubPointerDown = undefined;
+        marker.unsubPointerUp?.();
+        marker.unsubPointerUp = undefined;
     }
 }

--- a/src/lib/services/map/renderer/dom/dragController.ts
+++ b/src/lib/services/map/renderer/dom/dragController.ts
@@ -1,5 +1,4 @@
 import type {LatLngLiteral, MapProvider} from '$lib/interfaces/map';
-import {setDraggable} from '$lib/services/map/map.svelte';
 import type {Marker} from '$lib/services/map/marker';
 import {removeDragTimeout, setDragTimeout} from '$lib/state/marker.svelte';
 
@@ -81,7 +80,7 @@ export class DragController {
             marker.setPosition(latLng);
         });
         this.skipClick = true;
-        setDraggable(false);
+        this.provider.setDraggable(false);
         marker.getOnDragStart()?.();
         element.classList.add('marker-dragging');
     }
@@ -106,7 +105,7 @@ export class DragController {
         return () => {
             removeDragTimeout();
             this.removeMapMoveListener(marker);
-            setDraggable(true);
+            this.provider.setDraggable(true);
             if (marker.isDragged) {
                 marker.isDragged = false;
                 marker.getOnDragEnd()?.();

--- a/src/lib/services/map/renderer/dom/dragController.ts
+++ b/src/lib/services/map/renderer/dom/dragController.ts
@@ -79,12 +79,10 @@ export class DragController {
         if (!element) {
             return;
         }
-        marker.pointerMoveListener = this.provider.onPointerMove(
-            (latLng: LatLngLiteral) => {
-                marker.isDragged = true;
-                marker.setPosition(latLng);
-            },
-        );
+        marker.pointerMoveListener = this.provider.onPointerMove((latLng: LatLngLiteral) => {
+            marker.isDragged = true;
+            marker.setPosition(latLng);
+        });
         this.skipClick = true;
         setDraggable(false);
         marker.getOnDragStart()?.();

--- a/src/lib/services/map/renderer/dom/factory.ts
+++ b/src/lib/services/map/renderer/dom/factory.ts
@@ -1,11 +1,11 @@
 import MarkerIcon from '$lib/components/map/markerIcon.svelte';
-import type {IMapProvider} from '$lib/interfaces/map';
+import type {MapProvider} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
 import {cn} from '$lib/utils';
 import {mount} from 'svelte';
 
 export class Factory {
-    public constructor(private provider: IMapProvider) {}
+    public constructor(private provider: MapProvider) {}
 
     public create(marker: Marker): void {
         const content = this.createMarkerContent(marker);

--- a/src/lib/services/map/renderer/dom/factory.ts
+++ b/src/lib/services/map/renderer/dom/factory.ts
@@ -1,12 +1,18 @@
 import MarkerIcon from '$lib/components/map/markerIcon.svelte';
+import type {IMapProvider} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
 import {cn} from '$lib/utils';
 import {mount} from 'svelte';
 
 export class Factory {
+    public constructor(private provider: IMapProvider) {}
+
     public create(marker: Marker): void {
-        const raw = this.createAdvancedMarkerElement(marker, this.createMarkerContent(marker));
-        marker.setRaw(raw);
+        const content = this.createMarkerContent(marker);
+        const handle = this.provider.createMarkerHandle(marker.getPosition(), content, {
+            zIndex: marker.getSource() === 'search' ? 1 : 0,
+        });
+        marker.setHandle(handle);
         marker.create();
     }
 
@@ -27,18 +33,5 @@ export class Factory {
             },
         });
         return markerElement;
-    }
-
-    private createAdvancedMarkerElement(
-        marker: Marker,
-        content: HTMLElement,
-    ): google.maps.marker.AdvancedMarkerElement {
-        return new google.maps.marker.AdvancedMarkerElement({
-            position: marker.getPosition(),
-            content,
-            collisionBehavior: google.maps.CollisionBehavior.REQUIRED,
-            gmpClickable: true,
-            zIndex: marker.getSource() === 'search' ? 1 : 0,
-        });
     }
 }

--- a/src/lib/services/map/renderer/dom/styler.ts
+++ b/src/lib/services/map/renderer/dom/styler.ts
@@ -4,29 +4,29 @@ import type {Marker} from '$lib/services/map/marker';
 export class Styler {
     public apply(marker: Marker) {
         const {isVisited, isRemoved} = marker.getState();
-        const markerContent = marker.getRaw()?.content;
-        if (!markerContent || !(markerContent instanceof HTMLElement)) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             return;
         }
 
-        this.applyVisited(markerContent, isVisited, marker.getColor());
-        this.applyRemoved(markerContent, isRemoved);
+        this.applyVisited(element, isVisited, marker.getColor());
+        this.applyRemoved(element, isRemoved);
     }
 
-    private applyVisited(markerContent: HTMLElement, isVisited: boolean, markerColor: string) {
-        markerContent.style.boxShadow = `0 0 0 3px white, 0 0 0 5px ${markerColor}40, 0 2px 4px rgba(0,0,0,0.2)`;
+    private applyVisited(element: HTMLElement, isVisited: boolean, markerColor: string) {
+        element.style.boxShadow = `0 0 0 3px white, 0 0 0 5px ${markerColor}40, 0 2px 4px rgba(0,0,0,0.2)`;
 
         if (isVisited) {
             const borderColor = getContrastingColor(markerColor);
-            markerContent.style.boxShadow = `0 0 0 3px ${borderColor}, 0 0 0 5px ${markerColor}40, 0 2px 4px rgba(0,0,0,0.2)`;
+            element.style.boxShadow = `0 0 0 3px ${borderColor}, 0 0 0 5px ${markerColor}40, 0 2px 4px rgba(0,0,0,0.2)`;
         }
     }
 
-    private applyRemoved(markerContent: HTMLElement, isRemoved: boolean) {
-        markerContent.classList.remove('opacity-50');
+    private applyRemoved(element: HTMLElement, isRemoved: boolean) {
+        element.classList.remove('opacity-50');
 
         if (isRemoved) {
-            markerContent.classList.add('opacity-50');
+            element.classList.add('opacity-50');
         }
     }
 }

--- a/src/lib/services/map/renderer/domMarkerRenderer.ts
+++ b/src/lib/services/map/renderer/domMarkerRenderer.ts
@@ -1,3 +1,4 @@
+import type {IMapProvider} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
 import {DragController} from '$lib/services/map/renderer/dom/dragController';
 import {Factory} from '$lib/services/map/renderer/dom/factory';
@@ -5,9 +6,14 @@ import {Styler} from '$lib/services/map/renderer/dom/styler';
 import type {MarkerRenderer} from '$lib/services/map/renderer/markerRenderer';
 
 export class DomMarkerRenderer implements MarkerRenderer {
-    private factory = new Factory();
-    private dragController = new DragController();
+    private factory: Factory;
+    private dragController: DragController;
     private styler = new Styler();
+
+    public constructor(provider: IMapProvider) {
+        this.factory = new Factory(provider);
+        this.dragController = new DragController(provider);
+    }
 
     public ensureCreated(marker: Marker): void {
         if (!marker.isCreated()) {
@@ -22,13 +28,12 @@ export class DomMarkerRenderer implements MarkerRenderer {
     }
 
     public show(marker: Marker): void {
-        const raw = marker.getRaw();
-        if (!raw) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             return;
         }
 
         this.applyState(marker);
-        const element = raw.content as HTMLElement;
         element.classList.add('animate-popin');
         setTimeout(() => {
             element.classList.remove('animate-popin');
@@ -42,13 +47,12 @@ export class DomMarkerRenderer implements MarkerRenderer {
     }
 
     public remove(marker: Marker, onRemoved?: () => void): void {
-        const raw = marker.getRaw();
-        if (!raw) {
+        const element = marker.getHandle()?.getElement();
+        if (!element) {
             onRemoved?.();
             return;
         }
 
-        const element = raw.content as HTMLElement;
         element.classList.add('animate-popout');
         setTimeout(() => {
             element.classList.remove('animate-popout');

--- a/src/lib/services/map/renderer/domMarkerRenderer.ts
+++ b/src/lib/services/map/renderer/domMarkerRenderer.ts
@@ -1,4 +1,4 @@
-import type {IMapProvider} from '$lib/interfaces/map';
+import type {MapProvider} from '$lib/interfaces/map';
 import type {Marker} from '$lib/services/map/marker';
 import {DragController} from '$lib/services/map/renderer/dom/dragController';
 import {Factory} from '$lib/services/map/renderer/dom/factory';
@@ -10,7 +10,7 @@ export class DomMarkerRenderer implements MarkerRenderer {
     private dragController: DragController;
     private styler = new Styler();
 
-    public constructor(provider: IMapProvider) {
+    public constructor(provider: MapProvider) {
         this.factory = new Factory(provider);
         this.dragController = new DragController(provider);
     }

--- a/src/lib/services/map/streetView.svelte.ts
+++ b/src/lib/services/map/streetView.svelte.ts
@@ -1,4 +1,4 @@
-import {getGoogleProvider} from '$lib/state/map.svelte';
+import {getGoogleProvider} from '$lib/services/map/providers/google/provider';
 import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
 export function getStreetView(lat: number, lng: number) {

--- a/src/lib/services/map/streetView.svelte.ts
+++ b/src/lib/services/map/streetView.svelte.ts
@@ -1,8 +1,13 @@
-import {getGoogleProvider} from '$lib/services/map/providers/google/provider';
+import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
+import {mapState} from '$lib/state/map.svelte';
 import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
 export function getStreetView(lat: number, lng: number) {
-    const provider = getGoogleProvider();
+    const provider = mapState.provider;
+    if (!(provider instanceof GoogleMapsProvider)) {
+        return Promise.reject(new Error('Google Maps provider not available'));
+    }
+
     const googleMap = provider.getGoogleMap();
     if (!googleMap) {
         return Promise.reject(new Error('Map not initialized'));

--- a/src/lib/services/map/streetView.svelte.ts
+++ b/src/lib/services/map/streetView.svelte.ts
@@ -1,7 +1,8 @@
-import {mapState} from '$lib/state/map.svelte';
+import {getGoogleProvider} from '$lib/state/map.svelte';
 import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
 export function getStreetView(lat: number, lng: number) {
+    const provider = getGoogleProvider();
     const streetView = new google.maps.StreetViewService();
     return streetView
         .getPanorama({
@@ -10,8 +11,9 @@ export function getStreetView(lat: number, lng: number) {
         })
         .then(({data}: google.maps.StreetViewResponse) => {
             const location = data.location!;
-            if (mapState.map) {
-                const pano = mapState.map.getStreetView();
+            const googleMap = provider.getGoogleMap();
+            if (googleMap) {
+                const pano = googleMap.getStreetView();
                 pano.setPano(location.pano as string);
                 pano.setVisible(true);
                 objectDetailsOverlay.isMinimized = true;

--- a/src/lib/services/map/streetView.svelte.ts
+++ b/src/lib/services/map/streetView.svelte.ts
@@ -3,6 +3,11 @@ import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
 
 export function getStreetView(lat: number, lng: number) {
     const provider = getGoogleProvider();
+    const googleMap = provider.getGoogleMap();
+    if (!googleMap) {
+        return Promise.reject(new Error('Map not initialized'));
+    }
+
     const streetView = new google.maps.StreetViewService();
     return streetView
         .getPanorama({
@@ -11,12 +16,9 @@ export function getStreetView(lat: number, lng: number) {
         })
         .then(({data}: google.maps.StreetViewResponse) => {
             const location = data.location!;
-            const googleMap = provider.getGoogleMap();
-            if (googleMap) {
-                const pano = googleMap.getStreetView();
-                pano.setPano(location.pano as string);
-                pano.setVisible(true);
-                objectDetailsOverlay.isMinimized = true;
-            }
+            const pano = googleMap.getStreetView();
+            pano.setPano(location.pano as string);
+            pano.setVisible(true);
+            objectDetailsOverlay.isMinimized = true;
         });
 }

--- a/src/lib/services/map/viewportIndex.ts
+++ b/src/lib/services/map/viewportIndex.ts
@@ -1,13 +1,14 @@
+import type {LatLngLiteral, MapBounds} from '$lib/interfaces/map';
 import type {MarkerId} from '$lib/interfaces/marker';
 import type {MarkerRepository} from './markerRepository';
 
 export interface ViewportCandidate {
     id: MarkerId;
-    position: google.maps.LatLngLiteral;
+    position: LatLngLiteral;
 }
 
 export class ViewportIndex {
-    public collect(bounds: google.maps.LatLngBounds, repo: MarkerRepository): ViewportCandidate[] {
+    public collect(bounds: MapBounds, repo: MarkerRepository): ViewportCandidate[] {
         const allMarkersInViewport: ViewportCandidate[] = [];
 
         for (const id of repo.ids()) {
@@ -22,7 +23,7 @@ export class ViewportIndex {
 
     public selectVisible(
         candidates: ViewportCandidate[],
-        center: google.maps.LatLngLiteral,
+        center: LatLngLiteral,
         limit: number,
     ): Set<string> {
         const sorted = this.sortByDistance(candidates, center);
@@ -31,7 +32,7 @@ export class ViewportIndex {
 
     private sortByDistance(
         markers: ViewportCandidate[],
-        center: google.maps.LatLngLiteral,
+        center: LatLngLiteral,
     ): ViewportCandidate[] {
         return markers.sort((a, b) => {
             const distanceA = this.calculateDistance(a.position, center);
@@ -51,10 +52,7 @@ export class ViewportIndex {
         return visibleIds;
     }
 
-    private calculateDistance(
-        pos1: google.maps.LatLngLiteral,
-        pos2: google.maps.LatLngLiteral,
-    ): number {
+    private calculateDistance(pos1: LatLngLiteral, pos2: LatLngLiteral): number {
         const lat1 = (pos1.lat * Math.PI) / 180;
         const lat2 = (pos2.lat * Math.PI) / 180;
         const deltaLat = ((pos2.lat - pos1.lat) * Math.PI) / 180;

--- a/src/lib/services/map/viewportIndex.ts
+++ b/src/lib/services/map/viewportIndex.ts
@@ -1,6 +1,6 @@
 import type {LatLngLiteral, MapBounds} from '$lib/interfaces/map';
 import type {MarkerId} from '$lib/interfaces/marker';
-import type {MarkerRepository} from './markerRepository';
+import type {MarkerRepository} from '$lib/services/map/markerRepository';
 
 export interface ViewportCandidate {
     id: MarkerId;

--- a/src/lib/state/activeMarker.svelte.ts
+++ b/src/lib/state/activeMarker.svelte.ts
@@ -17,32 +17,23 @@ export function clearActiveMarker() {
 }
 
 export function deactivateMarker(marker: Marker | null = activeMarker.marker) {
-    const markerElement = getMarkerElement(marker);
-    if (!markerElement) {
+    const element = marker?.getHandle()?.getElement();
+    if (!element) {
         return;
     }
 
-    markerElement.classList.remove('scale-120');
-    markerElement.classList.remove('duration-100');
+    element.classList.remove('scale-120');
+    element.classList.remove('duration-100');
 }
 
 export function activateMarker(marker: Marker | null = activeMarker.marker) {
-    const markerElement = getMarkerElement(marker);
-    if (!markerElement) {
+    const element = marker?.getHandle()?.getElement();
+    if (!element) {
         return;
     }
 
-    markerElement.classList.add('duration-100');
+    element.classList.add('duration-100');
     requestAnimationFrame(() => {
-        markerElement.classList.add('scale-120');
+        element.classList.add('scale-120');
     });
-}
-
-function getMarkerElement(marker: Marker | null) {
-    const rawMarker = marker?.getRaw();
-    if (!rawMarker) {
-        return null;
-    }
-
-    return rawMarker.content instanceof HTMLElement ? rawMarker.content : null;
 }

--- a/src/lib/state/map.svelte.ts
+++ b/src/lib/state/map.svelte.ts
@@ -1,23 +1,26 @@
-import config from '$lib/config';
+import type {IMapProvider} from '$lib/interfaces/map';
 import type {MarkerManager} from '$lib/services/map/markerManager';
-import {Loader} from '@googlemaps/js-api-loader';
+import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
 
 interface MapState {
-    loader: Loader;
-    map?: google.maps.Map;
+    provider: IMapProvider;
+    isReady: boolean;
     markerManager?: MarkerManager;
     deckEnabled: boolean;
     streetViewVisible: boolean;
 }
 
 export const mapState = $state<MapState>({
-    loader: new Loader({
-        apiKey: config.googleMapsApiKey,
-        version: 'weekly',
-        libraries: ['places', 'marker'],
-    }),
-    map: undefined,
+    provider: new GoogleMapsProvider(),
+    isReady: false,
     markerManager: undefined,
     deckEnabled: false,
     streetViewVisible: false,
 });
+
+export function getGoogleProvider(): GoogleMapsProvider {
+    if (!(mapState.provider instanceof GoogleMapsProvider)) {
+        throw new Error('Expected GoogleMapsProvider');
+    }
+    return mapState.provider;
+}

--- a/src/lib/state/map.svelte.ts
+++ b/src/lib/state/map.svelte.ts
@@ -1,9 +1,8 @@
 import type {IMapProvider} from '$lib/interfaces/map';
 import type {MarkerManager} from '$lib/services/map/markerManager';
-import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
 
 interface MapState {
-    provider: IMapProvider;
+    provider: IMapProvider | null;
     isReady: boolean;
     markerManager?: MarkerManager;
     deckEnabled: boolean;
@@ -11,16 +10,9 @@ interface MapState {
 }
 
 export const mapState = $state<MapState>({
-    provider: new GoogleMapsProvider(),
+    provider: null,
     isReady: false,
     markerManager: undefined,
     deckEnabled: false,
     streetViewVisible: false,
 });
-
-export function getGoogleProvider(): GoogleMapsProvider {
-    if (!(mapState.provider instanceof GoogleMapsProvider)) {
-        throw new Error('Expected GoogleMapsProvider');
-    }
-    return mapState.provider;
-}

--- a/src/lib/state/map.svelte.ts
+++ b/src/lib/state/map.svelte.ts
@@ -1,8 +1,8 @@
-import type {IMapProvider} from '$lib/interfaces/map';
+import type {MapProvider} from '$lib/interfaces/map';
 import type {MarkerManager} from '$lib/services/map/markerManager';
 
 interface MapState {
-    provider: IMapProvider | null;
+    provider: MapProvider | null;
     isReady: boolean;
     markerManager?: MarkerManager;
     deckEnabled: boolean;

--- a/src/routes/(app)/(fullList)/+layout.svelte
+++ b/src/routes/(app)/(fullList)/+layout.svelte
@@ -111,7 +111,7 @@
     </div>
 {/if}
 
-{#if mapState.map}
+{#if mapState.isReady}
     {#each markerPoints as point (point.id)}
         <Marker
             id={point.id}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -70,7 +70,7 @@
 <div bind:this={consoleElement}></div>
 
 <div class="menu absolute top-2 right-4 left-2 flex items-center justify-between gap-4">
-    {#if mapState.map && clerkCtx.auth.userId}
+    {#if mapState.isReady && clerkCtx.auth.userId}
         <Search />
     {:else}
         <div></div>
@@ -85,7 +85,7 @@
 
 {@render children?.()}
 
-{#if mapState.map}
+{#if mapState.isReady}
     <LocationMarker {orientationEnabled} />
 
     {#each Object.keys(searchPointList) as searchPointId (searchPointId)}


### PR DESCRIPTION
Introduces IMapProvider and IMarkerHandle interfaces that decouple the
map module from Google Maps. All Google Maps-specific code is consolidated
into services/map/providers/google/, making it straightforward to add
alternative providers (e.g. OpenStreetMap/Leaflet) later.

Key changes:
- Add src/lib/interfaces/map.ts with IMapProvider, IMarkerHandle, MapBounds
- Add GoogleMapsProvider, GoogleMarkerHandle, GoogleMapBounds implementations
- Move DeckOverlayRenderer and HybridMarkerRenderer into google provider dir
- Marker class now holds IMarkerHandle instead of AdvancedMarkerElement
- MarkerManager takes IMapProvider + RendererFactory instead of google.maps.Map
- DragController uses provider.onPointerMove instead of google.maps.event
- Factory uses provider.createMarkerHandle instead of AdvancedMarkerElement directly
- mapState exposes provider: IMapProvider + isReady flag instead of raw map/loader
- Google-specific components (streetView, streetViewOverlay) use getGoogleProvider()
- Search items call marker.getOnClick() instead of google.maps.event.trigger

https://claude.ai/code/session_013VyQoAXvLUkFZ8bmgY7wNj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Map system migrated to a unified provider + marker-handle model for more consistent marker rendering and behavior.
* **Bug Fixes**
  * Improved readiness gating and subscribe/unsubscribe handling to prevent stray listeners, race conditions, and strengthen Street View/center/zoom reliability.
  * More reliable marker click, drag, and orientation handling across devices.
* **Chores**
  * Standardized imports and internal plumbing for steadier search, position, and overlay interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->