### PR TITLE
Restricting the min zoom level to avoid too small map view.

### DIFF
--- a/src/lib/components/map/map.svelte
+++ b/src/lib/components/map/map.svelte
@@ -49,6 +49,8 @@
         new PointerDragZoomController({
             getZoom: () => mapState.provider!.getZoom(),
             setZoom: zoom => mapState.provider!.setZoom(zoom),
+            getMinZoom: () => mapState.provider!.getMinZoom(),
+            getMaxZoom: () => mapState.provider!.getMaxZoom(),
             onStart: () => {
                 clearTimeout(clickTimeout);
                 clickTimeout = undefined;

--- a/src/lib/interfaces/map.ts
+++ b/src/lib/interfaces/map.ts
@@ -36,6 +36,8 @@ export interface MarkerHandle {
 export interface MapProvider {
     getZoom(): number;
     setZoom(zoom: number): void;
+    getMinZoom(): number;
+    getMaxZoom(): number;
     getCenter(): LatLngLiteral | undefined;
     getBounds(): MapBounds | undefined;
     setCenter(lat: number, lng: number): void;

--- a/src/lib/services/map/mapMinZoom.ts
+++ b/src/lib/services/map/mapMinZoom.ts
@@ -1,0 +1,12 @@
+const MERCATOR_WORLD_PX = 256;
+const MIN_ZOOM_FLOOR = 2;
+const MIN_ZOOM_CEIL = 4;
+
+export function computeMinZoomForContainer(container: HTMLElement): number {
+    const span = Math.max(container.clientWidth, container.clientHeight);
+    if (span < 1) {
+        return MIN_ZOOM_FLOOR;
+    }
+    const raw = Math.ceil(Math.log2(span / MERCATOR_WORLD_PX));
+    return Math.max(MIN_ZOOM_FLOOR, Math.min(MIN_ZOOM_CEIL, raw));
+}

--- a/src/lib/services/map/mapRestriction.ts
+++ b/src/lib/services/map/mapRestriction.ts
@@ -1,0 +1,9 @@
+export const MERCATOR_WORLD_RESTRICTION: google.maps.MapRestriction = {
+    latLngBounds: {
+        north: 85.0511287798066,
+        south: -85.0511287798066,
+        west: -180,
+        east: 180,
+    },
+    strictBounds: true,
+};

--- a/src/lib/services/map/pointerDragZoom.ts
+++ b/src/lib/services/map/pointerDragZoom.ts
@@ -3,6 +3,8 @@ import {throttle} from '$lib/utils';
 export type PointerDragZoomOptions = {
     getZoom(): number;
     setZoom(zoom: number): void;
+    getMinZoom?(): number;
+    getMaxZoom?(): number;
     onStart?(): void;
     onEnd?(): void;
 };
@@ -104,7 +106,9 @@ export class PointerDragZoomController {
         }
         const deltaY = currentY - this.initialY;
         const zoomDelta = deltaY / 50;
-        const newZoom = Math.max(1, Math.min(20, this.initialZoom + zoomDelta));
+        const minZ = this.options.getMinZoom?.() ?? 1;
+        const maxZ = this.options.getMaxZoom?.() ?? 20;
+        const newZoom = Math.max(minZ, Math.min(maxZ, this.initialZoom + zoomDelta));
         this.options.setZoom(newZoom);
     }
 

--- a/src/lib/services/map/providers/google/provider.ts
+++ b/src/lib/services/map/providers/google/provider.ts
@@ -9,14 +9,20 @@ import type {
     MarkerHandle,
     MarkerHandleOptions,
 } from '$lib/interfaces/map';
+import {computeMinZoomForContainer} from '$lib/services/map/mapMinZoom';
+import {MERCATOR_WORLD_RESTRICTION} from '$lib/services/map/mapRestriction';
 import {GoogleMapBounds} from '$lib/services/map/providers/google/bounds';
 import {GoogleMarkerHandle} from '$lib/services/map/providers/google/markerHandle';
 import {themeState} from '$lib/state/theme.svelte';
 import {Loader} from '@googlemaps/js-api-loader';
 
+const MAP_MAX_ZOOM = 21;
+
 export class GoogleMapsProvider implements MapProvider {
     readonly loader: Loader;
     private map?: google.maps.Map;
+    private minZoom = 2;
+    private resizeObserver?: ResizeObserver;
 
     constructor() {
         this.loader = new Loader({
@@ -32,9 +38,14 @@ export class GoogleMapsProvider implements MapProvider {
             this.loader.importLibrary('core'),
         ]);
 
+        this.minZoom = computeMinZoomForContainer(container);
+        const initialZoom = Math.max(center.zoom ?? 15, this.minZoom);
+
         this.map = new Map(container, {
-            zoom: center.zoom ?? 15,
+            zoom: initialZoom,
             center,
+            minZoom: this.minZoom,
+            maxZoom: MAP_MAX_ZOOM,
             mapId: config.googleMapsId,
             controlSize: 40,
             mapTypeControl: false,
@@ -43,7 +54,18 @@ export class GoogleMapsProvider implements MapProvider {
             zoomControl: false,
             clickableIcons: false,
             colorScheme: this.resolveColorScheme(ColorScheme),
+            restriction: MERCATOR_WORLD_RESTRICTION,
         });
+
+        this.resizeObserver = new ResizeObserver(() => {
+            const next = computeMinZoomForContainer(container);
+            if (next === this.minZoom) {
+                return;
+            }
+            this.minZoom = next;
+            this.map?.setOptions({minZoom: next});
+        });
+        this.resizeObserver.observe(container);
     }
 
     private resolveColorScheme(
@@ -57,6 +79,14 @@ export class GoogleMapsProvider implements MapProvider {
 
     getZoom(): number {
         return this.map?.getZoom() ?? 15;
+    }
+
+    getMinZoom(): number {
+        return this.minZoom;
+    }
+
+    getMaxZoom(): number {
+        return MAP_MAX_ZOOM;
     }
 
     setZoom(zoom: number): void {
@@ -173,6 +203,8 @@ export class GoogleMapsProvider implements MapProvider {
     }
 
     destroy(): void {
+        this.resizeObserver?.disconnect();
+        this.resizeObserver = undefined;
         if (this.map) {
             google.maps.event.clearInstanceListeners(this.map);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Map zoom interactions now respect defined minimum and maximum zoom bounds during drag and double-tap gestures, preventing over-zooming or under-zooming
  * Zoom constraints are intelligently computed based on container size and automatically recalculate when the container is resized
  * Enhanced map boundary enforcement with improved world map restriction settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->