### PR TITLE
Changing the way service markers are rendered; turning new point marker into a search marker

### DIFF
--- a/src/lib/interfaces/marker.ts
+++ b/src/lib/interfaces/marker.ts
@@ -16,7 +16,7 @@ export interface MarkerOptions {
     onDragEnd?(): void;
 }
 
-export type MarkerSource = 'map' | 'list' | 'search' | 'share';
+export type MarkerSource = 'map' | 'list' | 'search' | 'share' | 'draft';
 
 export type MarkerId = string;
 

--- a/src/lib/services/map/marker.ts
+++ b/src/lib/services/map/marker.ts
@@ -38,6 +38,30 @@ export class Marker {
         return this.options.source;
     }
 
+    public isLazy(): boolean {
+        return this.options.source === 'list';
+    }
+
+    public isServiceMarker(): boolean {
+        return (
+            this.options.source === 'share' ||
+            this.options.source === 'search' ||
+            this.options.source === 'draft'
+        );
+    }
+
+    public usesDomRenderer(): boolean {
+        return this.isServiceMarker();
+    }
+
+    public getZIndex(): number {
+        return this.isServiceMarker() ? 1 : 0;
+    }
+
+    public isViewportManaged(): boolean {
+        return this.options.source !== 'share';
+    }
+
     public getColor(): string {
         return this.options.color;
     }

--- a/src/lib/services/map/markerManager.ts
+++ b/src/lib/services/map/markerManager.ts
@@ -63,8 +63,6 @@ export class MarkerManager {
     }
 
     public addMarker(id: MarkerId, position: LatLngLiteral, options: MarkerOptions): Marker | null {
-        const isLazy = options.source === 'list';
-
         const upsert = this.repo.upsertWithPolicy(
             id,
             () => new Marker(position, options),
@@ -79,7 +77,7 @@ export class MarkerManager {
             this.renderer.ensureCreated(upsert.marker);
         }
 
-        if (isLazy) {
+        if (upsert.marker.isLazy()) {
             this.scheduleViewportUpdate();
             return upsert.marker;
         }
@@ -94,12 +92,17 @@ export class MarkerManager {
         }
 
         this.renderer.ensureCreated(marker);
-
-        if (marker.getSource() === 'map' || marker.getSource() === 'search') {
-            this.scheduleViewportUpdate();
-        }
+        this.scheduleViewportUpdateFor(marker);
 
         return marker;
+    }
+
+    private scheduleViewportUpdateFor(marker: Marker) {
+        if (!marker.isViewportManaged()) {
+            return;
+        }
+
+        this.scheduleViewportUpdate();
     }
 
     public getMarker(id: MarkerId): Marker | undefined {

--- a/src/lib/services/map/markerRepository.ts
+++ b/src/lib/services/map/markerRepository.ts
@@ -1,4 +1,4 @@
-import type {MarkerId} from '$lib/interfaces/marker';
+import type {MarkerId, MarkerSource} from '$lib/interfaces/marker';
 import {Marker} from './marker';
 
 export class MarkerRepository {
@@ -57,7 +57,7 @@ export class MarkerRepository {
     public upsertWithPolicy(
         id: MarkerId,
         createMarker: () => Marker,
-        source: 'map' | 'list' | 'search' | 'share',
+        source: MarkerSource,
     ): {action: 'inserted' | 'ignored' | 'replaced'; marker: Marker} {
         const existing = this.markerCache.get(id);
         if (!existing) {

--- a/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
+++ b/src/lib/services/map/providers/google/hybridMarkerRenderer.ts
@@ -22,54 +22,35 @@ export class HybridMarkerRenderer implements MarkerRenderer {
     }
 
     public ensureCreated(marker: Marker): void {
-        if (marker.getSource() === 'search') {
-            this.dom.ensureCreated(marker);
-        } else {
-            this.deck.ensureCreated(marker);
-        }
+        this.rendererFor(marker).ensureCreated(marker);
     }
 
     public syncAll(iterable: Iterable<Marker>): void {
-        // Only non-search markers are part of deck layer's global sync
-        const nonSearch: Marker[] = [];
+        const deckMarkers: Marker[] = [];
         for (const marker of iterable) {
-            if (marker.getSource() !== 'search') {
-                nonSearch.push(marker);
+            if (marker.usesDomRenderer()) {
+                this.dom.ensureCreated(marker);
+            } else {
+                deckMarkers.push(marker);
             }
         }
-        this.deck.syncAll(nonSearch);
+        this.deck.syncAll(deckMarkers);
     }
 
     public show(marker: Marker): void {
-        if (marker.getSource() === 'search') {
-            this.dom.show(marker);
-        } else {
-            this.deck.show(marker);
-        }
+        this.rendererFor(marker).show(marker);
     }
 
     public hide(marker: Marker): void {
-        if (marker.getSource() === 'search') {
-            this.dom.hide(marker);
-        } else {
-            this.deck.hide(marker);
-        }
+        this.rendererFor(marker).hide(marker);
     }
 
     public remove(marker: Marker, onRemoved?: () => void): void {
-        if (marker.getSource() === 'search') {
-            this.dom.remove(marker, onRemoved);
-        } else {
-            this.deck.remove(marker, onRemoved);
-        }
+        this.rendererFor(marker).remove(marker, onRemoved);
     }
 
     public applyState(marker: Marker): void {
-        if (marker.getSource() === 'search') {
-            this.dom.applyState(marker);
-        } else {
-            this.deck.applyState(marker);
-        }
+        this.rendererFor(marker).applyState(marker);
     }
 
     public destroy(): void {
@@ -83,5 +64,9 @@ export class HybridMarkerRenderer implements MarkerRenderer {
         } catch (e) {
             console.error('error destroying DeckOverlayRenderer:', e);
         }
+    }
+
+    private rendererFor(marker: Marker): MarkerRenderer {
+        return marker.usesDomRenderer() ? this.dom : this.deck;
     }
 }

--- a/src/lib/services/map/renderer/dom/factory.ts
+++ b/src/lib/services/map/renderer/dom/factory.ts
@@ -11,7 +11,7 @@ export class Factory {
     public create(marker: Marker): void {
         const content = this.createMarkerContent(marker);
         const handle = this.provider.createMarkerHandle(marker.getPosition(), content, {
-            zIndex: marker.getSource() === 'search' ? 1 : 0,
+            zIndex: marker.getZIndex(),
         });
         marker.setHandle(handle);
         marker.create();
@@ -19,7 +19,7 @@ export class Factory {
 
     private createMarkerContent(marker: Marker): HTMLElement {
         const markerElement = document.createElement('div');
-        const isInverted = marker.getSource() === 'share' || marker.getSource() === 'search';
+        const isInverted = marker.isServiceMarker();
         const color = marker.getColor();
         markerElement.className = `w-6 h-6 translate-y-1/2 flex justify-center items-center rounded-full transition-transform transition-opacity duration-100 ease-in-out text-sm ${isInverted ? '' : 'text-white'}`;
         markerElement.style.backgroundColor = isInverted ? 'white' : color;

--- a/src/lib/services/map/renderer/dom/styler.ts
+++ b/src/lib/services/map/renderer/dom/styler.ts
@@ -5,7 +5,7 @@ const VISITED_BRIGHT = '#39ff14';
 
 export class Styler {
     public apply(marker: Marker) {
-        if (marker.getSource() === 'share' || marker.getSource() === 'search') {
+        if (marker.isServiceMarker()) {
             return;
         }
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -134,8 +134,8 @@
                 lng={createDraftState.position.lng}
                 icon={SproutIcon}
                 iconClassName="fill-current"
-                color="#000000"
-                source="map"
+                color="#16a34a"
+                source="draft"
             />
         {/key}
     {/if}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft markers now appear green to distinguish draft locations.

* **Behavior Changes**
  * Some marker types now load lazily for smoother list interactions.
  * Service-type markers (share/search/draft) render differently and are layered above standard map markers, improving visual stacking and styling.
  * Viewport update scheduling has been adjusted so only markers that opt into viewport management trigger map viewport refreshes.

* **Refactor**
  * Marker handling unified behind query-style predicates for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->