### PR TITLE
Fix crowded category row layout when category is hidden

### DIFF
--- a/src/lib/components/settings/categoryStyleEditor.svelte
+++ b/src/lib/components/settings/categoryStyleEditor.svelte
@@ -51,10 +51,10 @@
         </div>
     </div>
 
-    <div class="border-border/40 mt-3 flex items-center justify-between border-t pt-3">
-        <IconPicker value={style.markerIcon} onchange={icon => onupdate({markerIcon: icon})} />
-        <div class="flex flex-col items-end gap-1">
-            <label class="flex cursor-pointer items-center gap-2 select-none">
+    <div class="border-border/40 mt-3 border-t pt-3">
+        <div class="flex items-center justify-between gap-3">
+            <IconPicker value={style.markerIcon} onchange={icon => onupdate({markerIcon: icon})} />
+            <label class="flex shrink-0 cursor-pointer items-center gap-2 select-none">
                 <ListXIcon class="text-muted-foreground size-3.5" />
                 <span class="text-muted-foreground text-xs">Скрыть из списка</span>
                 <Checkbox
@@ -62,11 +62,11 @@
                     onCheckedChange={checked => onupdate({isHidden: Boolean(checked)})}
                 />
             </label>
-            {#if style.isHidden}
-                <span class="text-muted-foreground/70 text-xs leading-tight">
-                    Не будет показана при выборе категории
-                </span>
-            {/if}
         </div>
+        {#if style.isHidden}
+            <p class="text-muted-foreground/70 mt-2 text-right text-xs leading-tight">
+                Не будет показана при выборе категории
+            </p>
+        {/if}
     </div>
 </div>


### PR DESCRIPTION
Move the hidden-category explanation onto its own full-width row below
the icon picker and checkbox so the wrapping text no longer skews the
row height and misaligns the icon button.

https://claude.ai/code/session_01J3aMfCREuMPhh17XoRWsG4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured the "hide from list" section in the category style editor with improved layout organization and visual alignment.
  * Enhanced the presentation of explanatory text through updated typography, spacing, and text alignment for better clarity and readability when the section is active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ngranko/radioatelier/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->