### PR TITLE
Fix user lastLoginAt and lastActiveAt population

### DIFF
--- a/src/convex/helpers/clerkTimestamps.test.ts
+++ b/src/convex/helpers/clerkTimestamps.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest';
+import {clerkTimestamp} from './clerkTimestamps';
+
+describe('clerkTimestamp', () => {
+    it('returns null for invalid values', () => {
+        expect(clerkTimestamp(null)).toBeNull();
+        expect(clerkTimestamp(undefined)).toBeNull();
+        expect(clerkTimestamp('1654012591514')).toBeNull();
+    });
+
+    it('keeps millisecond timestamps unchanged', () => {
+        expect(clerkTimestamp(1_654_012_591_514)).toBe(1_654_012_591_514);
+    });
+
+    it('converts second timestamps to milliseconds', () => {
+        expect(clerkTimestamp(1_654_012_591)).toBe(1_654_012_591_000);
+    });
+});

--- a/src/convex/helpers/clerkTimestamps.ts
+++ b/src/convex/helpers/clerkTimestamps.ts
@@ -1,0 +1,8 @@
+export function clerkTimestamp(value: unknown): number | null {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return null;
+    }
+
+    // Clerk webhook timestamps are usually milliseconds; older payloads may use seconds.
+    return value < 1_000_000_000_000 ? value * 1000 : value;
+}

--- a/src/convex/http.ts
+++ b/src/convex/http.ts
@@ -38,8 +38,7 @@ http.route({
                 const session = event.data as SessionJSON;
                 const clerkUserId = session.user_id;
                 const lastLoginAt = clerkTimestamp(session.created_at);
-                const lastActiveAt =
-                    clerkTimestamp(session.last_active_at) ?? lastLoginAt;
+                const lastActiveAt = clerkTimestamp(session.last_active_at) ?? lastLoginAt;
                 if (!clerkUserId || lastLoginAt === null || lastActiveAt === null) {
                     console.error('Received session.created event without required session data');
                     return new Response('Invalid event data', {status: 400});

--- a/src/convex/http.ts
+++ b/src/convex/http.ts
@@ -1,8 +1,9 @@
-import type {WebhookEvent} from '@clerk/backend';
+import type {SessionJSON, WebhookEvent} from '@clerk/backend';
 import {httpRouter} from 'convex/server';
 import {Webhook} from 'svix';
 import {internal} from './_generated/api';
 import {httpAction} from './_generated/server';
+import {clerkTimestamp} from './helpers/clerkTimestamps';
 import {getNotionWebhookVerificationToken} from './notion/config';
 import {verifyNotionWebhookSignature} from './notion/webhooks';
 
@@ -31,6 +32,23 @@ http.route({
                     return new Response('Invalid event data', {status: 400});
                 }
                 await ctx.runMutation(internal.users.deleteFromClerk, {clerkUserId});
+                break;
+            }
+            case 'session.created': {
+                const session = event.data as SessionJSON;
+                const clerkUserId = session.user_id;
+                const lastLoginAt = clerkTimestamp(session.created_at);
+                const lastActiveAt =
+                    clerkTimestamp(session.last_active_at) ?? lastLoginAt;
+                if (!clerkUserId || lastLoginAt === null || lastActiveAt === null) {
+                    console.error('Received session.created event without required session data');
+                    return new Response('Invalid event data', {status: 400});
+                }
+                await ctx.runMutation(internal.users.recordSessionFromClerk, {
+                    clerkUserId,
+                    lastActiveAt,
+                    lastLoginAt,
+                });
                 break;
             }
             default:

--- a/src/convex/users.ts
+++ b/src/convex/users.ts
@@ -1,6 +1,8 @@
 import type {UserJSON} from '@clerk/backend';
 import {v, type Validator} from 'convex/values';
-import {internalMutation, query, type QueryCtx} from './_generated/server';
+import type {Doc} from './_generated/dataModel';
+import {internalMutation, mutation, query, type QueryCtx} from './_generated/server';
+import {clerkTimestamp} from './helpers/clerkTimestamps';
 
 export const current = query({
     args: {},
@@ -9,30 +11,63 @@ export const current = query({
     },
 });
 
-export const upsertFromClerk = internalMutation({
-    args: {data: v.any() as Validator<UserJSON>}, // no runtime validation, trust Clerk
-    async handler(ctx, {data}) {
-        const userAttributes = {
-            email: data.email_addresses[0]?.email_address ?? '',
-            externalId: data.id,
-            role:
-                typeof data.public_metadata.role === 'string' ? data.public_metadata.role : 'user',
-            notionSyncEnabled: data.public_metadata.notionSyncEnabled === true,
-            notionUserId:
-                typeof data.public_metadata.notionUserId === 'string'
-                    ? data.public_metadata.notionUserId
-                    : undefined,
-            lastActiveAt: data.last_active_at,
-            lastLoginAt: data.last_sign_in_at,
-            isDeleted: false,
-        };
-
-        const user = await getUserByExternalId(ctx, data.id);
-        if (user === null) {
-            await ctx.db.insert('users', userAttributes);
-        } else {
-            await ctx.db.patch('users', user._id, userAttributes);
+export const recordActivity = mutation({
+    args: {isLogin: v.optional(v.boolean())},
+    handler: async (ctx, {isLogin}) => {
+        const user = await getCurrentUser(ctx);
+        if (!user) {
+            return;
         }
+
+        const now = Date.now();
+        await ctx.db.patch(user._id, {
+            lastActiveAt: now,
+            ...(isLogin ? {lastLoginAt: now} : {}),
+        });
+    },
+});
+
+export const upsertFromClerk = internalMutation({
+    args: {data: v.any() as Validator<UserJSON>},
+    async handler(ctx, {data}) {
+        const userAttributes = buildClerkUserAttributes(data);
+        const timestampFields = buildClerkTimestampFields(data);
+        const user = await getUserByExternalId(ctx, data.id);
+
+        if (user === null) {
+            await ctx.db.insert('users', {
+                ...userAttributes,
+                lastActiveAt: timestampFields.lastActiveAt,
+                lastLoginAt: timestampFields.lastLoginAt,
+            });
+            return;
+        }
+
+        const patch: Partial<Doc<'users'>> = {...userAttributes};
+        if (timestampFields.lastActiveAt !== null) {
+            patch.lastActiveAt = timestampFields.lastActiveAt;
+        }
+        if (timestampFields.lastLoginAt !== null) {
+            patch.lastLoginAt = timestampFields.lastLoginAt;
+        }
+        await ctx.db.patch(user._id, patch);
+    },
+});
+
+export const recordSessionFromClerk = internalMutation({
+    args: {
+        clerkUserId: v.string(),
+        lastActiveAt: v.number(),
+        lastLoginAt: v.number(),
+    },
+    handler: async (ctx, {clerkUserId, lastActiveAt, lastLoginAt}) => {
+        const user = await getUserByExternalId(ctx, clerkUserId);
+        if (user === null) {
+            console.warn(`Can't record session, there is no user for Clerk user ID: ${clerkUserId}`);
+            return;
+        }
+
+        await ctx.db.patch(user._id, {lastActiveAt, lastLoginAt});
     },
 });
 
@@ -42,7 +77,7 @@ export const deleteFromClerk = internalMutation({
         const user = await getUserByExternalId(ctx, clerkUserId);
 
         if (user !== null) {
-            await ctx.db.patch('users', user._id, {isDeleted: true});
+            await ctx.db.patch(user._id, {isDeleted: true});
         } else {
             console.warn(`Can't delete user, there is none for Clerk user ID: ${clerkUserId}`);
         }
@@ -80,4 +115,26 @@ export async function getUserByNotionUserId(ctx: QueryCtx, notionUserId: string)
         .withIndex('byNotionUserId', q => q.eq('notionUserId', notionUserId))
         .filter(q => q.eq(q.field('isDeleted'), false))
         .unique();
+}
+
+function buildClerkUserAttributes(data: UserJSON) {
+    return {
+        email: data.email_addresses[0]?.email_address ?? '',
+        externalId: data.id,
+        role:
+            typeof data.public_metadata.role === 'string' ? data.public_metadata.role : 'user',
+        notionSyncEnabled: data.public_metadata.notionSyncEnabled === true,
+        notionUserId:
+            typeof data.public_metadata.notionUserId === 'string'
+                ? data.public_metadata.notionUserId
+                : undefined,
+        isDeleted: false,
+    };
+}
+
+function buildClerkTimestampFields(data: Pick<UserJSON, 'last_active_at' | 'last_sign_in_at'>) {
+    return {
+        lastActiveAt: clerkTimestamp(data.last_active_at),
+        lastLoginAt: clerkTimestamp(data.last_sign_in_at),
+    };
 }

--- a/src/convex/users.ts
+++ b/src/convex/users.ts
@@ -44,10 +44,16 @@ export const upsertFromClerk = internalMutation({
         }
 
         const patch: Partial<Doc<'users'>> = {...userAttributes};
-        if (timestampFields.lastActiveAt !== null) {
+        if (
+            timestampFields.lastActiveAt !== null &&
+            (user.lastActiveAt === null || timestampFields.lastActiveAt > user.lastActiveAt)
+        ) {
             patch.lastActiveAt = timestampFields.lastActiveAt;
         }
-        if (timestampFields.lastLoginAt !== null) {
+        if (
+            timestampFields.lastLoginAt !== null &&
+            (user.lastLoginAt === null || timestampFields.lastLoginAt > user.lastLoginAt)
+        ) {
             patch.lastLoginAt = timestampFields.lastLoginAt;
         }
         await ctx.db.patch(user._id, patch);
@@ -63,11 +69,23 @@ export const recordSessionFromClerk = internalMutation({
     handler: async (ctx, {clerkUserId, lastActiveAt, lastLoginAt}) => {
         const user = await getUserByExternalId(ctx, clerkUserId);
         if (user === null) {
-            console.warn(`Can't record session, there is no user for Clerk user ID: ${clerkUserId}`);
+            console.warn(
+                `Can't record session, there is no user for Clerk user ID: ${clerkUserId}`,
+            );
             return;
         }
 
-        await ctx.db.patch(user._id, {lastActiveAt, lastLoginAt});
+        const patch: Partial<Doc<'users'>> = {};
+        if (user.lastActiveAt === null || lastActiveAt > user.lastActiveAt) {
+            patch.lastActiveAt = lastActiveAt;
+        }
+        if (user.lastLoginAt === null || lastLoginAt > user.lastLoginAt) {
+            patch.lastLoginAt = lastLoginAt;
+        }
+
+        if ('lastActiveAt' in patch || 'lastLoginAt' in patch) {
+            await ctx.db.patch(user._id, patch);
+        }
     },
 });
 
@@ -121,8 +139,7 @@ function buildClerkUserAttributes(data: UserJSON) {
     return {
         email: data.email_addresses[0]?.email_address ?? '',
         externalId: data.id,
-        role:
-            typeof data.public_metadata.role === 'string' ? data.public_metadata.role : 'user',
+        role: typeof data.public_metadata.role === 'string' ? data.public_metadata.role : 'user',
         notionSyncEnabled: data.public_metadata.notionSyncEnabled === true,
         notionUserId:
             typeof data.public_metadata.notionUserId === 'string'

--- a/src/lib/components/convexClerkAuth.svelte
+++ b/src/lib/components/convexClerkAuth.svelte
@@ -42,12 +42,18 @@
                     return null;
                 }
             });
-            void convexClient.mutation(api.users.recordActivity, {isLogin});
+            void (async () => {
+                try {
+                    await convexClient.mutation(api.users.recordActivity, {isLogin});
+                    appliedAuthUserId = nextAuthUserId;
+                } catch (err) {
+                    console.error('Failed to record Convex user activity', err);
+                }
+            })();
         } else {
             convexClient.client.clearAuth();
+            appliedAuthUserId = null;
         }
-
-        appliedAuthUserId = nextAuthUserId;
     });
 </script>
 

--- a/src/lib/components/convexClerkAuth.svelte
+++ b/src/lib/components/convexClerkAuth.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import {api} from '$convex/_generated/api';
     import {useConvexClient} from 'convex-svelte';
     import {useClerkContext} from 'svelte-clerk';
     import type {Snippet} from 'svelte';
@@ -24,6 +25,7 @@
         }
 
         if (nextAuthUserId) {
+            const isLogin = appliedAuthUserId === null;
             convexClient.setAuth(async ({forceRefreshToken}) => {
                 try {
                     if (!clerkCtx.session) {
@@ -40,6 +42,7 @@
                     return null;
                 }
             });
+            void convexClient.mutation(api.users.recordActivity, {isLogin});
         } else {
             convexClient.client.clearAuth();
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`lastLoginAt` and `lastActiveAt` were not being reliably populated because Clerk user webhooks often omit `last_active_at`, and `upsertFromClerk` always patched both fields — including when Clerk sent `null` on metadata-only `user.updated` events.

## Changes

- **Client activity tracking:** Added `users.recordActivity` and call it from `convexClerkAuth.svelte` when a Clerk session is connected to Convex. This sets `lastActiveAt` on each authenticated visit and `lastLoginAt` when the user transitions from signed out to signed in.
- **Session webhook support:** Handle Clerk `session.created` events to record sign-in timestamps server-side.
- **Safer Clerk upserts:** Normalize Clerk timestamps and only patch `lastLoginAt` / `lastActiveAt` when Clerk provides non-null values.
- **Tests:** Added unit tests for timestamp normalization.

## Ops note

For server-side sign-in tracking via webhooks, enable the `session.created` event on the existing Clerk webhook endpoint (`POST /clerk-users-webhook`). Client-side `recordActivity` will populate fields even without this, but the webhook provides a reliable backup.

## Test plan

- [x] `npm test`
- [ ] Sign in and confirm `lastLoginAt` and `lastActiveAt` are set on the user document
- [ ] Reload the app and confirm `lastActiveAt` updates
- [ ] (Optional) Enable `session.created` in Clerk and confirm sign-in updates timestamps via webhook
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f45e16cb-84cd-4d10-8647-ec291e81c62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f45e16cb-84cd-4d10-8647-ec291e81c62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded webhook processing to handle Clerk session creation events
  * Implemented user activity tracking to record login events and session activity timestamps

* **Tests**
  * Introduced test coverage for timestamp normalization across different timestamp formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->