### PR TITLE
Add Esc shortcut to close active overlays and popups

### DIFF
--- a/src/lib/components/escapeCloseHandler.svelte
+++ b/src/lib/components/escapeCloseHandler.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+    import {onMount} from 'svelte';
+    import {dispatchEscapeClose} from '$lib/utils/escapeClose';
+
+    onMount(() => {
+        function onKeydown(event: KeyboardEvent) {
+            if (event.key !== 'Escape') {
+                return;
+            }
+
+            if (!dispatchEscapeClose()) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        window.addEventListener('keydown', onKeydown, true);
+
+        return () => {
+            window.removeEventListener('keydown', onKeydown, true);
+        };
+    });
+</script>

--- a/src/lib/components/input/imageUpload/imageViewer.svelte
+++ b/src/lib/components/input/imageUpload/imageViewer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import {fade} from 'svelte/transition';
     import {cubicInOut} from 'svelte/easing';
+    import {onMount} from 'svelte';
+    import {registerEscapeCloseHandler} from '$lib/utils/escapeClose';
 
     interface Props {
         isOpen: boolean;
@@ -12,6 +14,14 @@
     function handleClose() {
         isOpen = false;
     }
+
+    onMount(() =>
+        registerEscapeCloseHandler({
+            priority: 30,
+            isActive: () => isOpen,
+            close: handleClose,
+        }),
+    );
 </script>
 
 {#if isOpen}

--- a/src/lib/components/map/streetView.svelte
+++ b/src/lib/components/map/streetView.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
     import StreetViewOverlay from '$lib/components/map/streetViewOverlay.svelte';
     import {cn} from '$lib/utils';
-    import {onDestroy} from 'svelte';
+    import {onDestroy, onMount} from 'svelte';
     import {mapState} from '$lib/state/map.svelte';
     import {GoogleMapsProvider} from '$lib/services/map/providers/google/provider';
     import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
+    import {registerEscapeCloseHandler} from '$lib/utils/escapeClose';
 
     let streetViewContainer: HTMLDivElement | undefined = $state();
     let panorama: google.maps.StreetViewPanorama | null = $state(null);
@@ -84,6 +85,14 @@
         mapState.streetViewVisible = false;
         panorama = null;
     });
+
+    onMount(() =>
+        registerEscapeCloseHandler({
+            priority: 40,
+            isActive: () => mapState.streetViewVisible,
+            close: () => mapState.provider?.closeStreetView(),
+        }),
+    );
 </script>
 
 <div class="pointer-events-none fixed inset-0 z-2">

--- a/src/lib/components/objectDetails/background.svelte
+++ b/src/lib/components/objectDetails/background.svelte
@@ -1,57 +1,17 @@
 <script lang="ts">
     import {mapState} from '$lib/state/map.svelte';
-    import {
-        Root as DialogRoot,
-        Trigger,
-        Content,
-        Header,
-        Title,
-        Description,
-        Footer,
-        Close,
-    } from '$lib/components/ui/dialog';
-    import {Button} from '$lib/components/ui/button';
 
     interface Props {
-        isConfirmationRequired?: boolean;
-        onClick(): void;
+        onRequestClose(): void;
     }
 
-    let {isConfirmationRequired = false, onClick}: Props = $props();
+    let {onRequestClose}: Props = $props();
 </script>
 
-{#if isConfirmationRequired}
-    <DialogRoot>
-        <Trigger
-            class={`fixed inset-0 z-1 bg-transparent ${
-                mapState.streetViewVisible ? 'pointer-events-none' : ''
-            }`}
-        ></Trigger>
-        <Content>
-            <Header>
-                <Title>Вы действительно хотите выйти из редактирования точки?</Title>
-                <Description>Изменения не будут сохранены</Description>
-            </Header>
-            <Footer>
-                <Close>
-                    <Button variant="ghost">Отменить</Button>
-                </Close>
-                <Button
-                    variant="ghost"
-                    class="text-destructive hover:text-destructive"
-                    onclick={onClick}
-                >
-                    Закрыть
-                </Button>
-            </Footer>
-        </Content>
-    </DialogRoot>
-{:else}
-    <button
-        type="button"
-        aria-label="Close object details"
-        class="fixed inset-0 z-1 bg-transparent"
-        class:pointer-events-none={mapState.streetViewVisible}
-        onclick={onClick}
-    ></button>
-{/if}
+<button
+    type="button"
+    aria-label="Close object details"
+    class="fixed inset-0 z-1 bg-transparent"
+    class:pointer-events-none={mapState.streetViewVisible}
+    onclick={onRequestClose}
+></button>

--- a/src/lib/components/objectDetails/closeButton.svelte
+++ b/src/lib/components/objectDetails/closeButton.svelte
@@ -1,50 +1,14 @@
 <script lang="ts">
-    import {
-        Root as AlertDialogRoot,
-        Trigger,
-        Content,
-        Header,
-        Title,
-        Description,
-        Footer,
-        Cancel,
-        Action,
-    } from '$lib/components/ui/alert-dialog';
-    import {Button, buttonVariants} from '$lib/components/ui/button';
-    import {cn} from '$lib/utils.ts';
+    import {Button} from '$lib/components/ui/button';
     import XMarkIcon from '@lucide/svelte/icons/x';
 
     interface Props {
-        isConfirmationRequired?: boolean;
-        onClick(): void;
+        onRequestClose(): void;
     }
 
-    let {isConfirmationRequired = false, onClick}: Props = $props();
+    let {onRequestClose}: Props = $props();
 </script>
 
-{#if isConfirmationRequired}
-    <AlertDialogRoot>
-        <Trigger
-            type="button"
-            class={cn([buttonVariants({variant: 'ghost', size: 'icon'}), 'h-8 w-8'])}
-        >
-            <XMarkIcon class="stroke-3" />
-        </Trigger>
-        <Content>
-            <Header>
-                <Title>Вы действительно хотите выйти из редактирования точки?</Title>
-                <Description>Изменения не будут сохранены</Description>
-            </Header>
-            <Footer>
-                <Cancel>Отменить</Cancel>
-                <Action class="bg-destructive hover:bg-destructive/70" onclick={onClick}>
-                    Закрыть
-                </Action>
-            </Footer>
-        </Content>
-    </AlertDialogRoot>
-{:else}
-    <Button variant="ghost" size="icon" class="h-8 w-8" onclick={onClick}>
-        <XMarkIcon class="stroke-3" />
-    </Button>
-{/if}
+<Button variant="ghost" size="icon" class="h-8 w-8" onclick={onRequestClose}>
+    <XMarkIcon class="stroke-3" />
+</Button>

--- a/src/lib/components/objectDetails/objectDetails.svelte
+++ b/src/lib/components/objectDetails/objectDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import {fade} from 'svelte/transition';
+    import {onMount} from 'svelte';
     import type {
         LooseObject,
         Object as ObjectType,
@@ -30,6 +31,17 @@
     import PointPreview from '$lib/components/objectDetails/pointPreview.svelte';
     import ViewMode from '$lib/components/objectDetails/viewMode/viewMode.svelte';
     import type {ObjectDetailsOverlayMode} from '$lib/state/objectDetailsOverlay.svelte';
+    import {
+        Root as AlertDialogRoot,
+        Content,
+        Header,
+        Title,
+        Description,
+        Footer,
+        Cancel,
+        Action,
+    } from '$lib/components/ui/alert-dialog';
+    import {registerEscapeCloseHandler} from '$lib/utils/escapeClose';
 
     interface Props {
         initialValues?: Partial<LooseObject>;
@@ -46,6 +58,8 @@
         mode = 'objectView',
         permissions = {canEditAll: true, canEditPersonal: true},
     }: Props = $props();
+
+    let isCloseConfirmOpen = $state(false);
 
     const resolvedInitialValues = $derived(initialValues ?? {});
     const resolvedMode = $derived(objectDetailsOverlay.isOpen ? objectDetailsOverlay.mode : mode);
@@ -69,6 +83,7 @@
     }
 
     function handleClose() {
+        isCloseConfirmOpen = false;
         setCreateDraftPosition(null);
         deactivateMarker();
         clearActiveMarker();
@@ -89,9 +104,42 @@
             objectDetailsOverlay.details = object;
         }
     }
+
+    function requestClose() {
+        if (objectDetailsOverlay.isDirty) {
+            isCloseConfirmOpen = true;
+            return;
+        }
+
+        handleClose();
+    }
+
+    onMount(() =>
+        registerEscapeCloseHandler({
+            priority: 20,
+            isActive: () => objectDetailsOverlay.isOpen,
+            close: requestClose,
+        }),
+    );
 </script>
 
-<Background onClick={handleClose} isConfirmationRequired={objectDetailsOverlay.isDirty} />
+<Background onRequestClose={requestClose} />
+{#if objectDetailsOverlay.isDirty}
+    <AlertDialogRoot bind:open={isCloseConfirmOpen}>
+        <Content>
+            <Header>
+                <Title>Вы действительно хотите выйти из редактирования точки?</Title>
+                <Description>Изменения не будут сохранены</Description>
+            </Header>
+            <Footer>
+                <Cancel>Отменить</Cancel>
+                <Action class="bg-destructive hover:bg-destructive/70" onclick={handleClose}>
+                    Закрыть
+                </Action>
+            </Footer>
+        </Content>
+    </AlertDialogRoot>
+{/if}
 <aside
     class={cn([
         'bg-background absolute bottom-0 z-3 m-2 flex w-[calc(100dvw-8px*2)] max-w-100 flex-col rounded-lg transition-[height]',
@@ -133,7 +181,7 @@
                 <ChevronDownIcon class="stroke-3" />
             {/if}
         </Button>
-        <CloseButton onClick={handleClose} isConfirmationRequired={objectDetailsOverlay.isDirty} />
+        <CloseButton onRequestClose={requestClose} />
     </section>
     <div class="relative flex-1 overflow-hidden">
         <div class="absolute inset-0" in:fade={{duration: 150}} out:fade={{duration: 150}}>

--- a/src/lib/components/search/searchBar.svelte
+++ b/src/lib/components/search/searchBar.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import ClearButton from '$lib/components/search/clearButton.svelte';
-    import {clearSearchPointList} from '$lib/state/searchPointList.svelte.ts';
-    import {searchState} from '$lib/state/search.svelte';
+    import {clearSearch, searchState} from '$lib/state/search.svelte';
+    import {objectDetailsOverlay} from '$lib/state/objectDetailsOverlay.svelte';
     import {mapState} from '$lib/state/map.svelte';
     import {Input} from '$lib/components/ui/input';
     import {fade} from 'svelte/transition';
     import {cubicInOut} from 'svelte/easing';
+    import {onMount} from 'svelte';
+    import {registerEscapeCloseHandler} from '$lib/utils/escapeClose';
     import SearchIcon from '@lucide/svelte/icons/search';
 
     let {disabled = false}: {disabled?: boolean} = $props();
@@ -35,15 +37,22 @@
     }
 
     function handleClearClick() {
-        searchState.query = '';
-        searchState.lat = '';
-        searchState.lng = '';
-        searchState.isResultsShown = false;
+        clearSearch();
         val = '';
         clearTimeout(timeout);
         timeout = undefined;
-        clearSearchPointList();
     }
+
+    onMount(() =>
+        registerEscapeCloseHandler({
+            priority: 10,
+            isActive: () =>
+                Boolean(searchState.query || val) &&
+                !objectDetailsOverlay.isOpen &&
+                !disabled,
+            close: handleClearClick,
+        }),
+    );
 </script>
 
 <div class="group relative z-1">

--- a/src/lib/state/search.svelte.ts
+++ b/src/lib/state/search.svelte.ts
@@ -1,3 +1,4 @@
+import {clearSearchPointList} from '$lib/state/searchPointList.svelte.ts';
 import {normalizeLatitude, normalizeLongitude} from '$lib/utils/coordinates.ts';
 
 export const searchState = $state({
@@ -39,6 +40,14 @@ export function applyUrlToSearchState(url: URL): boolean {
     }
 
     return false;
+}
+
+export function clearSearch() {
+    searchState.query = '';
+    searchState.lat = '';
+    searchState.lng = '';
+    searchState.isResultsShown = false;
+    clearSearchPointList();
 }
 
 export function getActiveSearchUrl(): string {

--- a/src/lib/utils/escapeClose.ts
+++ b/src/lib/utils/escapeClose.ts
@@ -1,0 +1,47 @@
+type EscapeCloseHandler = {
+    priority: number;
+    isActive: () => boolean;
+    close: () => void;
+};
+
+const handlers: EscapeCloseHandler[] = [];
+
+const OPEN_FLOATING_LAYER_SELECTOR = [
+    '[data-state="open"][data-slot="dialog-content"]',
+    '[data-state="open"][data-slot="alert-dialog-content"]',
+    '[data-state="open"][data-slot="popover-content"]',
+    '[data-state="open"][data-slot="dropdown-menu-content"]',
+    '[data-state="open"][data-slot="select-content"]',
+    '[data-state="open"][data-slot="dropdown-menu-sub-content"]',
+].join(', ');
+
+function hasOpenFloatingLayer(): boolean {
+    return document.querySelector(OPEN_FLOATING_LAYER_SELECTOR) !== null;
+}
+
+export function registerEscapeCloseHandler(handler: EscapeCloseHandler): () => void {
+    handlers.push(handler);
+    handlers.sort((a, b) => b.priority - a.priority);
+
+    return () => {
+        const index = handlers.indexOf(handler);
+        if (index !== -1) {
+            handlers.splice(index, 1);
+        }
+    };
+}
+
+export function dispatchEscapeClose(): boolean {
+    if (hasOpenFloatingLayer()) {
+        return false;
+    }
+
+    for (const handler of handlers) {
+        if (handler.isActive()) {
+            handler.close();
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -12,6 +12,7 @@
     import Marker from '$lib/components/map/marker.svelte';
     import UserMenu from '$lib/components/userMenu/userMenu.svelte';
     import Search from '$lib/components/search/search.svelte';
+    import EscapeCloseHandler from '$lib/components/escapeCloseHandler.svelte';
     import {sharedMarker} from '$lib/state/sharedMarker.svelte.ts';
     import {goto} from '$app/navigation';
     import {page} from '$app/state';
@@ -89,6 +90,8 @@
 </div>
 
 <Map onClick={handleMapClick} />
+
+<EscapeCloseHandler />
 
 <OrientationButton bind:isEnabled={orientationEnabled} />
 <PositionButton />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a global **Esc** shortcut that closes the topmost active overlay or popup, with sensible priority ordering and without interfering with bits-ui dialogs, popovers, or dropdowns.

## What works with Esc now

| Layer | Behavior |
|---|---|
| bits-ui dialogs / alert dialogs / popovers / dropdowns / selects | Unchanged — native Esc handling |
| Street View | Closes street view |
| Image viewer | Closes full-screen image preview |
| Object details overlay | Closes overlay; shows dirty-state confirmation when edits are unsaved |
| Search preview / results | Clears the active search |

## Implementation

- **`escapeClose.ts`** — priority registry; skips when a bits-ui floating layer is open
- **`escapeCloseHandler.svelte`** — global `keydown` listener mounted in the app layout
- **Object details** — close confirmation consolidated into a single alert dialog shared by the close button, backdrop, and Esc

## Testing

- Verified type/lint diagnostics on touched files
- Manual verification recommended: open object details (with and without unsaved edits), street view, image preview, and search — confirm Esc closes the topmost layer in order
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3764221-bfd4-4908-ad5f-2b1a36f6287d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3764221-bfd4-4908-ad5f-2b1a36f6287d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

